### PR TITLE
Setting correct length for BTSTACK_EVENT_STATE event.

### DIFF
--- a/ble/sm.c
+++ b/ble/sm.c
@@ -1365,7 +1365,7 @@ static void sm_handle_encryption_result(uint8_t * data){
             // SM INIT FINISHED, start application code - TODO untangle that
             if (sm_client_packet_handler)
             {
-                uint8_t event[] = { BTSTACK_EVENT_STATE, 0, HCI_STATE_WORKING };
+                uint8_t event[] = { BTSTACK_EVENT_STATE, 1, HCI_STATE_WORKING };
                 sm_client_packet_handler(HCI_EVENT_PACKET, 0, (uint8_t*) event, sizeof(event));
             }
             return;


### PR DESCRIPTION
The second byte of the data is the length of the remaining data (in this case the HCI_STATE_WORKING byte). This was passing 0 indicating that there was no data when in fact there was.