### PR TITLE
Fix build for WICED

### DIFF
--- a/port/wiced/wiced.mk
+++ b/port/wiced/wiced.mk
@@ -17,6 +17,7 @@ $(NAME)_SOURCES += \
 	../../src/ble/att_server.c   		  \
 	../../src/ble/le_device_db_memory.c   \
 	../../src/ble/sm.c          		  \
+	../../src/ble/ad_parser.c		\
 	../../src/classic/hsp_hs.c            \
 	../../src/classic/btstack_link_key_db_memory.c \
 	../../src/classic/rfcomm.c            \
@@ -44,7 +45,7 @@ $(NAME)_SOURCES += \
 	../../chipset/bcm/btstack_chipset_bcm.c    \
 
 ifeq ($(BT_CHIP_XTAL_FREQUENCY),)
-$(NAME)_SOURCES := ../../../drivers/bluetooth/firmware/$(BT_CHIP)$(BT_CHIP_REVISION)/bt_firmware_image.c
+$(NAME)_SOURCES += ../../../drivers/bluetooth/firmware/$(BT_CHIP)$(BT_CHIP_REVISION)/bt_firmware_image.c
 else
-$(NAME)_SOURCES := ../../../drivers/bluetooth/firmware/$(BT_CHIP)$(BT_CHIP_REVISION)/$(BT_CHIP_XTAL_FREQUENCY)/bt_firmware_image.c
+$(NAME)_SOURCES += ../../../drivers/bluetooth/firmware/$(BT_CHIP)$(BT_CHIP_REVISION)/$(BT_CHIP_XTAL_FREQUENCY)/bt_firmware_image.c
 endif


### PR DESCRIPTION
Need to use += for sources and add one more source file for the
gap_le_advertisements example.

Signed-off-by: Bruno Randolf <br1@einfach.org>