### PR TITLE
Change btstack_stdin.c to btstack_stdin_posix.c in Makefiles to fix c…

### DIFF
--- a/port/posix-h5-bcm/Makefile
+++ b/port/posix-h5-bcm/Makefile
@@ -12,7 +12,7 @@ CORE += \
 	le_device_db_fs.c \
 	main.c \
 	wav_util.c 					\
-	btstack_stdin.c \
+	btstack_stdin_posix.c \
 
 # examples
 include ${BTSTACK_ROOT}/example/Makefile.inc

--- a/port/posix-h5/Makefile
+++ b/port/posix-h5/Makefile
@@ -16,7 +16,7 @@ CORE += \
 	le_device_db_fs.c \
 	main.c \
 	wav_util.c 					\
-	btstack_stdin.c \
+	btstack_stdin_posix.c \
 
 # TI-WL183x requires TIInit_11.8.32.c
 


### PR DESCRIPTION
While compiling posix-h5-bcm and posix-h5 examples i found Makefile related errors:

_make: *** No rule to make target 'btstack_stdin.o', needed by 'avdtp_sink_demo'.  Stop._

Have changed btstack_stdin.c to btstack_stdin_posix.c. Now seems OK.

Cheers,
Taras. 