### PR TITLE
Fix attempt to free a non-heap object

### DIFF
--- a/platform/posix/btstack_tlv_posix.c
+++ b/platform/posix/btstack_tlv_posix.c
@@ -198,7 +198,6 @@ static int btstack_tlv_posix_read_db(btstack_tlv_posix_t * self){
 							btstack_linked_list_add(&self->entry_list, (btstack_linked_item_t *) new_entry);
 						} else {
 							// fail
-							free(entry);
 							break;
 						}
 					}	    		


### PR DESCRIPTION
I have found attempt to free a non-heap object warning while compiled btstack with -Wfree-nonheap-object flag.

uint8_t entry[8];
...
free(entry);

Cheers.