### PR TITLE
Ubx patches and changes

### DIFF
--- a/src/ble/att_db_util.c
+++ b/src/ble/att_db_util.c
@@ -96,6 +96,7 @@ static int att_db_util_assert_space(uint16_t size){
 	}
 	att_db = new_db;
 	att_db_max_size = new_size;
+    att_set_db(att_db); // Update att_db with the new db
 	return 1;
 #else
 	log_error("att_db: out of memory");

--- a/src/ble/att_db_util.h
+++ b/src/ble/att_db_util.h
@@ -55,6 +55,12 @@
 extern "C" {
 #endif
 
+typedef struct
+{
+    uint16_t          value_handle;       /**< Handle to the characteristic value. */
+    uint16_t          cccd_handle;        /**< Handle to the Client Characteristic Configuration Descriptor. */
+} att_db_handles;
+
 /* API_START */
 
 /**
@@ -65,26 +71,40 @@ void att_db_util_init(void);
 /**
  * @brief Add primary service for 16-bit UUID
  */
-void att_db_util_add_service_uuid16(uint16_t udid16);
+uint16_t att_db_util_add_service_uuid16(uint16_t udid16);
 
 /**
  * @brief Add primary service for 128-bit UUID
  */
-void att_db_util_add_service_uuid128(uint8_t * udid128);
+uint16_t att_db_util_add_service_uuid128(uint8_t * udid128);
 
 /**
  * @brief Add Characteristic with 16-bit UUID, properties, and data
  * @returns attribute value handle
  * @see ATT_PROPERTY_* in ble/att_db.h
  */
-uint16_t att_db_util_add_characteristic_uuid16(uint16_t   udid16,  uint16_t properties, uint8_t * data, uint16_t data_len);
+att_db_handles att_db_util_add_characteristic_uuid16(uint16_t   udid16, uint16_t properties, uint8_t * data, uint16_t data_len);
 
 /**
  * @brief Add Characteristic with 128-bit UUID, properties, and data
  * @returns attribute value handle
  * @see ATT_PROPERTY_* in ble/att_db.h
  */
-uint16_t att_db_util_add_characteristic_uuid128(uint8_t * udid128, uint16_t properties, uint8_t * data, uint16_t data_len);
+att_db_handles att_db_util_add_characteristic_uuid128(uint8_t * udid128, uint16_t properties, uint8_t * data, uint16_t data_len);
+
+/**
+* @brief Add descriptor with 16-bit UUID, properties, and data
+* @returns attribute value handle
+* @see ATT_PROPERTY_* in ble/att_db.h
+*/
+uint16_t att_db_util_add_descriptor_uuid16(uint16_t uuid16, uint16_t properties, uint8_t * data, uint16_t data_len);
+
+/**
+* @brief Add descriptor with 128-bit UUID, properties, and data
+* @returns attribute value handle
+* @see ATT_PROPERTY_* in ble/att_db.h
+*/
+uint16_t att_db_util_add_descriptor_uuid128(uint8_t * udid128, uint16_t properties, uint8_t * data, uint16_t data_len);
 
 /** 
  * @brief Get address of constructed ATT DB

--- a/src/ble/att_dispatch.c
+++ b/src/ble/att_dispatch.c
@@ -140,3 +140,23 @@ void att_dispatch_server_request_can_send_now_event(hci_con_handle_t con_handle)
 	att_server_waiting_for_can_send = 1;
 	l2cap_request_can_send_fix_channel_now_event(con_handle, L2CAP_CID_ATTRIBUTE_PROTOCOL);
 }
+
+void att_dispatch_server_mtu_exchanged(hci_con_handle_t con_handle, uint16_t new_mtu){
+    if (!att_client_handler) return;
+    uint8_t packet[6];
+    packet[0] = ATT_EVENT_MTU_EXCHANGE_COMPLETE;
+    packet[1] = sizeof(packet) - 2;
+    little_endian_store_16(packet, 2, con_handle);
+    little_endian_store_16(packet, 4, new_mtu);
+    att_client_handler(ATT_DATA_PACKET, con_handle, packet, 1);
+}
+
+void att_dispatch_client_mtu_exchanged(hci_con_handle_t con_handle, uint16_t new_mtu){
+    if (!att_server_handler) return;
+    uint8_t packet[6];
+    packet[0] = ATT_EVENT_MTU_EXCHANGE_COMPLETE;
+    packet[1] = sizeof(packet) - 2;
+    little_endian_store_16(packet, 2, con_handle);
+    little_endian_store_16(packet, 4, new_mtu);
+    att_server_handler(ATT_DATA_PACKET, con_handle, packet, 1);
+}

--- a/src/ble/att_dispatch.h
+++ b/src/ble/att_dispatch.h
@@ -89,6 +89,20 @@ void att_dispatch_client_request_can_send_now_event(hci_con_handle_t con_handle)
  */
 void att_dispatch_server_request_can_send_now_event(hci_con_handle_t con_handle);
 
+/** 
+* @brief Used for propogating a updated MTU from att_server to gatt_client
+* @param con_handle
+* @param mtu
+*/
+void att_dispatch_server_mtu_exchanged(hci_con_handle_t con_handle, uint16_t new_mtu);
+
+/**
+* @brief Used for propogating a updated MTU from gatt_client to att_server
+* @param con_handle
+* @param mtu
+*/
+void att_dispatch_client_mtu_exchanged(hci_con_handle_t con_handle, uint16_t new_mtu);
+
 #if defined __cplusplus
 }
 #endif

--- a/src/ble/att_server.c
+++ b/src/ble/att_server.c
@@ -117,6 +117,7 @@ static void att_emit_mtu_event(hci_con_handle_t con_handle, uint16_t mtu){
     little_endian_store_16(event, pos, con_handle);
     pos += 2;
     little_endian_store_16(event, pos, mtu);
+    att_dispatch_server_mtu_exchanged(con_handle, mtu);
     (*att_client_packet_handler)(HCI_EVENT_PACKET, 0, &event[0], sizeof(event));
 }
 
@@ -417,6 +418,11 @@ static void att_packet_handler(uint8_t packet_type, uint16_t handle, uint8_t *pa
             log_info("ATT Packet, handle 0x%04x", handle);
             att_server = att_server_for_handle(handle);
             if (!att_server) break;
+
+            // Gatt client have negotiated the mtu for this connection
+            if (packet[0] == ATT_EVENT_MTU_EXCHANGE_COMPLETE){
+                att_server->connection.mtu = little_endian_read_16(packet, 4);
+            }
 
             // handle value indication confirms
             if (packet[0] == ATT_HANDLE_VALUE_CONFIRMATION && att_server->value_indication_handle){

--- a/src/ble/gatt_client.c
+++ b/src/ble/gatt_client.c
@@ -569,6 +569,7 @@ static void emit_gatt_mtu_exchanged_result_event(gatt_client_t * peripheral, uin
     packet[1] = sizeof(packet) - 2;
     little_endian_store_16(packet, 2, peripheral->con_handle);
     little_endian_store_16(packet, 4, new_mtu);
+    att_dispatch_client_mtu_exchanged(peripheral->con_handle, new_mtu);
     emit_event_new(peripheral->callback, packet, sizeof(packet));
 }
 ///
@@ -1081,6 +1082,12 @@ static void gatt_client_att_packet_handler(uint8_t packet_type, uint16_t handle,
     if (!peripheral) return;
     
     switch (packet[0]){
+        // att_server has negotiated the mtu for this connection
+        case ATT_EVENT_MTU_EXCHANGE_COMPLETE:
+        {
+            peripheral->mtu = little_endian_read_16(packet, 4);
+            break;
+        }
         case ATT_EXCHANGE_MTU_RESPONSE:
         {
             uint16_t remote_rx_mtu = little_endian_read_16(packet, 1);

--- a/src/ble/gatt_client.c
+++ b/src/ble/gatt_client.c
@@ -1880,4 +1880,7 @@ void gatt_client_deserialize_characteristic(const uint8_t * packet, int offset, 
 void gatt_client_deserialize_characteristic_descriptor(const uint8_t * packet, int offset, gatt_client_characteristic_descriptor_t * descriptor){
     descriptor->handle = little_endian_read_16(packet, offset);
     reverse_128(&packet[offset+2], descriptor->uuid128);
+    if (uuid_has_bluetooth_prefix(descriptor->uuid128)){
+        descriptor->uuid16 = big_endian_read_32(descriptor->uuid128, 0);
+    }
 }

--- a/src/ble/gatt_client.c
+++ b/src/ble/gatt_client.c
@@ -551,8 +551,17 @@ static void emit_gatt_all_characteristic_descriptors_result_event(
     reverse_128(uuid128, &packet[6]);
     emit_event_new(peripheral->callback, packet, sizeof(packet));
 }
-///
 
+static void emit_gatt_mtu_exchanged_result_event(gatt_client_t * peripheral, uint16_t new_mtu){
+    // @format H2
+    uint8_t packet[6];
+    packet[0] = GATT_EVENT_MTU;
+    packet[1] = sizeof(packet) - 2;
+    little_endian_store_16(packet, 2, peripheral->con_handle);
+    little_endian_store_16(packet, 4, new_mtu);
+    emit_event_new(peripheral->callback, packet, sizeof(packet));
+}
+///
 static void report_gatt_services(gatt_client_t * peripheral, uint8_t * packet,  uint16_t size){
     uint8_t attr_length = packet[1];
     uint8_t uuid_length = attr_length - 4;
@@ -1068,7 +1077,7 @@ static void gatt_client_att_packet_handler(uint8_t packet_type, uint16_t handle,
             uint16_t local_rx_mtu = l2cap_max_le_mtu();
             peripheral->mtu = remote_rx_mtu < local_rx_mtu ? remote_rx_mtu : local_rx_mtu;
             peripheral->mtu_state = MTU_EXCHANGED;
-
+            emit_gatt_mtu_exchanged_result_event(peripheral, peripheral->mtu);
             break;
         }
         case ATT_READ_BY_GROUP_TYPE_RESPONSE:

--- a/src/ble/gatt_client.h
+++ b/src/ble/gatt_client.h
@@ -126,7 +126,8 @@ typedef enum {
 typedef enum{
     SEND_MTU_EXCHANGE,
     SENT_MTU_EXCHANGE,
-    MTU_EXCHANGED
+    MTU_EXCHANGED,
+    MTU_AUTO_EXCHANGE_DISABLED
 } gatt_client_mtu_t;
 
 typedef struct gatt_client{
@@ -217,6 +218,16 @@ void gatt_client_init(void);
  * @brief MTU is available after the first query has completed. If status is equal to 0, it returns the real value, otherwise the default value of 23. 
  */
 uint8_t gatt_client_get_mtu(hci_con_handle_t con_handle, uint16_t * mtu);
+
+/**
+* @brief Sets whether a MTU Exchange Request shall be automatically send before the first attribute read request is send.
+*/
+void gatt_client_mtu_enable_auto_negotiation(uint8_t enabled);
+
+/**
+* @brief Sends a MTU Exchange Request, this allows for the client to exchange MTU when gatt_client_mtu_enable_auto_negotiation is disabled.
+*/
+void gatt_client_send_mtu_negotiation(btstack_packet_handler_t callback, hci_con_handle_t con_handle);
 
 /** 
  * @brief Returns if the GATT client is ready to receive a query. It is used with daemon. 

--- a/src/gap.h
+++ b/src/gap.h
@@ -280,6 +280,8 @@ void gap_scan_response_set_data(uint8_t scan_response_data_length, uint8_t * sca
 
 /**
  * @brief Set connection parameters for outgoing connections
+ * @param conn_scan_interval (unit: 0.625 msec), default: 60 ms
+ * @param conn_scan_window (unit: 0.625 msec), default: 30 ms
  * @param conn_interval_min (unit: 1.25ms), default: 10 ms
  * @param conn_interval_max (unit: 1.25ms), default: 30 ms
  * @param conn_latency, default: 4
@@ -287,9 +289,9 @@ void gap_scan_response_set_data(uint8_t scan_response_data_length, uint8_t * sca
  * @param min_ce_length (unit: 0.625ms), default: 10 ms
  * @param max_ce_length (unit: 0.625ms), default: 30 ms
  */
-
-void gap_set_connection_parameters(uint16_t conn_interval_min, uint16_t conn_interval_max,
-	uint16_t conn_latency, uint16_t supervision_timeout, uint16_t min_ce_length, uint16_t max_ce_length);
+void gap_set_connection_parameters(uint16_t conn_scan_interval, uint16_t conn_scan_window, 
+    uint16_t conn_interval_min, uint16_t conn_interval_max, uint16_t conn_latency,
+    uint16_t supervision_timeout, uint16_t min_ce_length, uint16_t max_ce_length);
 
 /**
  * @brief Request an update of the connection parameter for a given LE connection

--- a/src/hci.c
+++ b/src/hci.c
@@ -2449,6 +2449,8 @@ void hci_init(const hci_transport_t *transport, const void *config){
 
 #ifdef ENABLE_LE_CENTRAL
     // connection parameter to use for outgoing connections
+    hci_stack->le_connection_scan_interval = 0x0060;   // 60ms
+    hci_stack->le_connection_scan_window  = 0x0030;    // 30ms
     hci_stack->le_connection_interval_min = 0x0008;    // 10 ms
     hci_stack->le_connection_interval_max = 0x0018;    // 30 ms
     hci_stack->le_connection_latency      = 4;         // 4
@@ -3088,8 +3090,8 @@ static void hci_run(void){
             bd_addr_t null_addr;
             memset(null_addr, 0, 6);
             hci_send_cmd(&hci_le_create_connection,
-                 0x0060,    // scan interval: 60 ms
-                 0x0030,    // scan interval: 30 ms
+                hci_stack->le_connection_scan_interval,    // scan interval: 60 ms
+                hci_stack->le_connection_scan_window,    // scan interval: 30 ms
                  1,         // use whitelist
                  0,         // peer address type
                  null_addr, // peer bd addr
@@ -3125,8 +3127,8 @@ static void hci_run(void){
 #ifdef ENABLE_LE_CENTRAL
                         log_info("sending hci_le_create_connection");
                         hci_send_cmd(&hci_le_create_connection,
-                             0x0060,    // scan interval: 60 ms
-                             0x0030,    // scan interval: 30 ms
+                             hci_stack->le_connection_scan_interval,    // conn scan interval
+                             hci_stack->le_connection_scan_window,      // conn scan windows
                              0,         // don't use whitelist
                              connection->address_type, // peer address type
                              connection->address,      // peer bd addr
@@ -4067,6 +4069,8 @@ uint8_t gap_connect_cancel(void){
 #ifdef ENABLE_LE_CENTRAL
 /**
  * @brief Set connection parameters for outgoing connections
+ * @param conn_scan_interval (unit: 0.625 msec), default: 60 ms
+ * @param conn_scan_window (unit: 0.625 msec), default: 30 ms
  * @param conn_interval_min (unit: 1.25ms), default: 10 ms
  * @param conn_interval_max (unit: 1.25ms), default: 30 ms
  * @param conn_latency, default: 4
@@ -4075,8 +4079,11 @@ uint8_t gap_connect_cancel(void){
  * @param max_ce_length (unit: 0.625ms), default: 30 ms
  */
 
-void gap_set_connection_parameters(uint16_t conn_interval_min, uint16_t conn_interval_max,
-    uint16_t conn_latency, uint16_t supervision_timeout, uint16_t min_ce_length, uint16_t max_ce_length){
+void gap_set_connection_parameters(uint16_t conn_scan_interval, uint16_t conn_scan_window, 
+    uint16_t conn_interval_min, uint16_t conn_interval_max, uint16_t conn_latency,
+    uint16_t supervision_timeout, uint16_t min_ce_length, uint16_t max_ce_length){
+    hci_stack->le_connection_scan_interval = conn_scan_interval;
+    hci_stack->le_connection_scan_window = conn_scan_window;
     hci_stack->le_connection_interval_min = conn_interval_min;
     hci_stack->le_connection_interval_max = conn_interval_max;
     hci_stack->le_connection_latency = conn_latency;

--- a/src/hci.h
+++ b/src/hci.h
@@ -820,6 +820,10 @@ typedef struct {
     uint16_t le_supervision_timeout;
     uint16_t le_minimum_ce_length;
     uint16_t le_maximum_ce_length;
+
+    bd_addr_t le_cancel_connect_addr;
+    bd_addr_type_t le_cancel_connect_addr_type;
+
 #endif
 
     le_connection_parameter_range_t le_connection_parameter_range;

--- a/src/hci.h
+++ b/src/hci.h
@@ -820,6 +820,8 @@ typedef struct {
     uint16_t le_supervision_timeout;
     uint16_t le_minimum_ce_length;
     uint16_t le_maximum_ce_length;
+    uint16_t le_connection_scan_interval;
+    uint16_t le_connection_scan_window;
 
     bd_addr_t le_cancel_connect_addr;
     bd_addr_type_t le_cancel_connect_addr_type;

--- a/src/hci.h
+++ b/src/hci.h
@@ -854,6 +854,10 @@ typedef struct {
     bd_addr_t custom_bd_addr; 
     uint8_t   custom_bd_addr_set;
 
+#ifdef ENABLE_CLASSIC
+    uint8_t master_slave_policy;
+#endif
+
 } hci_stack_t;
 
 
@@ -1004,6 +1008,11 @@ uint8_t* hci_get_outgoing_packet_buffer(void);
  */
 void hci_release_packet_buffer(void);
 
+/**
+* @brief Sets the master/slave policy
+* @param policy (0: attempt to become master, 1: let connecting device decide)
+*/
+void hci_set_master_slave_policy(uint8_t policy);
 
 /* API_END */
 

--- a/src/hci_cmd.c
+++ b/src/hci_cmd.c
@@ -547,6 +547,13 @@ const hci_cmd_t hci_write_link_policy_settings = {
 OPCODE(OGF_LINK_POLICY, 0x0d), "H2"
 };
 
+/**
+ * @param policy
+ */
+const hci_cmd_t hci_write_default_link_policy_setup = {
+    OPCODE(OGF_LINK_POLICY, 0x0F), "2"
+};
+
 
 /**
  *  Controller & Baseband Commands 

--- a/src/hci_cmd.h
+++ b/src/hci_cmd.h
@@ -148,6 +148,7 @@ extern const hci_cmd_t hci_write_extended_inquiry_response;
 extern const hci_cmd_t hci_write_inquiry_mode;
 extern const hci_cmd_t hci_write_le_host_supported;
 extern const hci_cmd_t hci_write_link_policy_settings;
+extern const hci_cmd_t hci_write_default_link_policy_setup;
 extern const hci_cmd_t hci_write_link_supervision_timeout;
 extern const hci_cmd_t hci_write_local_name;
 extern const hci_cmd_t hci_write_loopback_mode;

--- a/src/l2cap.c
+++ b/src/l2cap.c
@@ -150,6 +150,7 @@ static l2cap_fixed_channel_t fixed_channels[L2CAP_FIXED_CHANNEL_TABLE_SIZE];
 #ifdef ENABLE_BLE
 // only used for connection parameter update events
 static btstack_packet_handler_t l2cap_event_packet_handler;
+static uint16_t custom_max_mtu;
 #endif
 
 #ifdef ENABLE_L2CAP_ENHANCED_RETRANSMISSION_MODE
@@ -707,6 +708,7 @@ void l2cap_init(void){
 
 #ifdef ENABLE_BLE
     l2cap_event_packet_handler = NULL;
+    custom_max_mtu = 0;
 #endif
     memset(fixed_channels, 0, sizeof(fixed_channels));
 
@@ -1122,7 +1124,14 @@ uint16_t l2cap_max_mtu(void){
 }
 
 uint16_t l2cap_max_le_mtu(void){
+    if (custom_max_mtu != 0) return custom_max_mtu;
     return l2cap_max_mtu();
+}
+
+void l2cap_set_max_le_mtu(uint16_t max_mtu){
+    if (max_mtu < l2cap_max_mtu()){
+        custom_max_mtu = max_mtu;
+    }
 }
 
 #ifdef ENABLE_CLASSIC

--- a/src/l2cap.h
+++ b/src/l2cap.h
@@ -390,6 +390,11 @@ uint16_t l2cap_max_mtu(void);
  */
 uint16_t l2cap_max_le_mtu(void);
 
+/**
+* @brief Set the max MTU for LE connections, if not set the l2cap_max_mtu will be used.
+*/
+void l2cap_set_max_le_mtu(uint16_t max_mtu);
+
 /** 
  * @brief Creates L2CAP channel to the PSM of a remote device with baseband address. A new baseband connection will be initiated if necessary.
  * @param packet_handler


### PR DESCRIPTION
Bug fixes and some smaller additions for functionality we needed.

Removed the disable_mtu_negotiation in the `att_server `, since setting `l2cap_set_max_le_mtu` does the same thing.
It's still required in the gatt_client.c thought, since we don't want to send a MTU negotiation at all.

For the GATT_EVENT_MTU, I can't see where it's being send, correct me if I'm wrong:
[see here](https://github.com/bluekitchen/btstack/search?utf8=%E2%9C%93&q=GATT_EVENT_MTU+&type=)