### PR TITLE
Fix packet_type of MTU exchange emit. Fix index in round robin.

### DIFF
--- a/src/ble/att_dispatch.c
+++ b/src/ble/att_dispatch.c
@@ -173,7 +173,7 @@ static void emit_mtu_exchange_complete(btstack_packet_handler_t packet_handler, 
     packet[1] = sizeof(packet) - 2;
     little_endian_store_16(packet, 2, con_handle);
     little_endian_store_16(packet, 4, new_mtu);
-    packet_handler(HCI_EVENT_PACKET, con_handle, packet, 1);
+    packet_handler(ATT_DATA_PACKET, con_handle, packet, 1);
 }
 
 void att_dispatch_server_mtu_exchanged(hci_con_handle_t con_handle, uint16_t new_mtu){

--- a/src/ble/att_dispatch.c
+++ b/src/ble/att_dispatch.c
@@ -90,7 +90,7 @@ static void att_packet_handler(uint8_t packet_type, uint16_t handle, uint8_t *pa
             // check if more can send now events are needed
             if (!can_send_now_pending){
                 for (i = 0; i < ATT_MAX; i++){
-                    if (subscriptions[index].waiting_for_can_send){
+                    if (subscriptions[i].waiting_for_can_send){
                         can_send_now_pending = 1;        
                         // note: con_handle is not used, so we can pass in anything
                         l2cap_request_can_send_fix_channel_now_event(0, L2CAP_CID_ATTRIBUTE_PROTOCOL);


### PR DESCRIPTION
The MTU exchange complete event was thrown away here because of its `packet_type`, causing the `gatt_client` to not update the MTU internally: https://github.com/bluekitchen/btstack/blob/49999da9ce4dd557f51e19b3c36101a9a3fe56b1/src/ble/gatt_client.c#L1079

Also I had problems where I called `att_server_request_can_send_now_event`, but didn't get a the callback, even thought I was allowed to send. Changing the index variable seems to have fixed the problem. Please take an extra look to see if this fix is enough.