### PR TITLE
MAX32630-FTHR: Include cc256x chipset dependency

### DIFF
--- a/port/max32630-fthr/example/template/Makefile
+++ b/port/max32630-fthr/example/template/Makefile
@@ -258,7 +258,7 @@ include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/$(COMPILER)/$(TARGET_LC).
 
 # fetch and convert init scripts
 # use bluetooth_init_cc2564B_1.6_BT_Spec_4.1.c
-# include ${BTSTACK_ROOT}/chipset/cc256x/Makefile.inc
+include ${BTSTACK_ROOT}/chipset/cc256x/Makefile.inc
 
 #include ${BTSTACK_ROOT}/example/Makefile.inc
 


### PR DESCRIPTION
fixes build error:
make[1]: *** No rule to make target '/bluetooth_init_cc2564B_1.6_BT_Spec_4.1.o', needed by '/btstack/port/max32630-fthr/example/sm_pairing_central/build/sm_pairing_central.elf'.  Stop.