### PR TITLE
hci: allow HCI_OUTGOING_PRE_BUFFER_SIZE to be overridden in btstack_config.h

### DIFF
--- a/src/hci.h
+++ b/src/hci.h
@@ -109,10 +109,12 @@ extern "C" {
 #endif
 
 // additional pre-buffer space for packets to Bluetooth module, for now, used for HCI Transport H4 DMA
+#ifndef HCI_OUTGOING_PRE_BUFFER_SIZE
 #ifdef HAVE_HOST_CONTROLLER_API
 #define HCI_OUTGOING_PRE_BUFFER_SIZE 0
 #else
 #define HCI_OUTGOING_PRE_BUFFER_SIZE 1
+#endif
 #endif
 
 // BNEP may uncompress the IP Header by 16 bytes


### PR DESCRIPTION
Very simple change allowing HCI_OUTGOING_PRE_BUFFER_SIZE to be modified at compile time without editing btstack source code.

I required this change in order to support both H4 and USB transports within the same build.
Only one is actively used, but the transport is selected at runtime.
The USB transport driver I am working with requires buffers to be 4 byte aligned, and the default value for HCI_OUTGOING_PRE_BUFFER_SIZE breaks this.

Increasing HCI_OUTGOING_PRE_BUFFER_SIZE to `4` allows the H4 transport to continue working and fixes the alignment issues I faced without requiring an intermediate buffer.