### PR TITLE
Fix for compile error in btstack_crypto.c.

### DIFF
--- a/src/btstack_crypto.c
+++ b/src/btstack_crypto.c
@@ -570,7 +570,7 @@ static void btstack_crypto_run(void){
             btstack_crypto_aes128 = (btstack_crypto_aes128_t *) btstack_crypto;
 #ifdef USE_BTSTACK_AES128
             btstack_aes128_calc(btstack_crypto_aes128->key, btstack_crypto_aes128->plaintext, btstack_crypto_aes128->ciphertext);
-            btstack_crypto_done();
+            btstack_crypto_done(btstack_crypto);
 #else
             btstack_crypto_aes128_start(btstack_crypto_aes128->key, btstack_crypto_aes128->plaintext);
 #endif


### PR DESCRIPTION
Fix for compile error in btstack_crypto.c.
    
    make btstack.le_counter-BCM94343WWCD2
    MAKEFILE MAKECMDGOALS=btstack.le_counter-BCM94343WWCD2 OTA2_SUPPORT is disabled
    ./tools/makefiles/wiced_elf.mk:218: warning: overriding commands for target `build/btstack.le_counter-BCM94343WWCD2/Modules/libraries/btstack/port/wiced-h5/../
    ./tools/makefiles/wiced_elf.mk:218: warning: ignoring old commands for target `build/btstack.le_counter-BCM94343WWCD2/Modules/libraries/btstack/port/wiced-h5/.
    Building Bootloader
    Finished Building Bootloader
    
    libraries/btstack/port/wiced-h5/../../src/btstack_crypto.c: In function 'btstack_crypto_run':
    libraries/btstack/port/wiced-h5/../../src/btstack_crypto.c:573:13: error: too few arguments to function 'btstack_crypto_done'
                 btstack_crypto_done();
