### PR TITLE
btstack: nvs flash erase if newer nvs version found

### DIFF
--- a/port/esp32/components/btstack/btstack_tlv_esp32.c
+++ b/port/esp32/components/btstack/btstack_tlv_esp32.c
@@ -142,7 +142,7 @@ static const btstack_tlv_t btstack_tlv_esp32 = {
 const btstack_tlv_t * btstack_tlv_esp32_get_instance(void){
 	// Initialize NVS
     esp_err_t err = nvs_flash_init();
-    if (err == ESP_ERR_NVS_NO_FREE_PAGES) {
+    if (err == ESP_ERR_NVS_NO_FREE_PAGES || err == ESP_ERR_NVS_NEW_VERSION_FOUND) {
 	    log_info("Error (0x%04x) init flash", err);
         // NVS partition was truncated and needs to be erased
         // Retry nvs_flash_init


### PR DESCRIPTION
do the nvs_flash_erase() + nvs_flash_init() if the first init
fails with ESP_ERR_NVS_NEW_VERSION_FOUND.

This can happen if someone tries esp-idf v3.3-stable (a newer nvs will be
used) and then switches back to esp-idf v3.1.2