### PR TITLE
hci-event: add support for remote_version_information_complete

### DIFF
--- a/src/btstack_event.h
+++ b/src/btstack_event.h
@@ -464,6 +464,52 @@ static inline uint8_t hci_event_master_link_key_complete_get_key_flag(const uint
 }
 
 /**
+ * @brief Get field status from event HCI_EVENT_READ_REMOTE_VERSION_INFORMATION_COMPLETE
+ * @param event packet
+ * @return status
+ * @note: btstack_type 1
+ */
+static inline uint8_t hci_event_read_remote_version_information_complete_get_status(const uint8_t * event) {
+    return event[2];
+}
+/**
+ * @brief Get field con_handle from event HCI_EVENT_READ_REMOTE_VERSION_INFORMATION_COMPLETE
+ * @param event packet
+ * @return handle
+ * @note: btstack_type 2
+ */
+static inline hci_con_handle_t hci_event_read_remote_version_information_complete_get_handle(const uint8_t * event) {
+    return little_endian_read_16(event, 3);
+}
+/**
+ * @brief Get field lmp_version from event HCI_EVENT_READ_REMOTE_VERSION_INFORMATION_COMPLETE
+ * @param event packet
+ * @return lmp_version
+ * @note: btstack_type 1
+ */
+static inline uint8_t hci_event_read_remote_version_information_complete_get_lmp_version(const uint8_t * event) {
+    return event[5];
+}
+/**
+ * @brief Get field manufacturer_name from event HCI_EVENT_READ_REMOTE_VERSION_INFORMATION_COMPLETE
+ * @param event packet
+ * @return manufacturer_name
+ * @note: btstack_type 2
+ */
+static inline uint8_t hci_event_read_remote_version_information_complete_get_manufacturer_name(const uint8_t * event) {
+    return little_endian_read_16(event, 6);
+}
+/**
+ * @brief Get field manufacturer_name from event HCI_EVENT_READ_REMOTE_VERSION_INFORMATION_COMPLETE
+ * @param event packet
+ * @return lmp_subversion
+ * @note: btstack_type 2
+ */
+static inline uint8_t hci_event_read_remote_version_information_complete_get_lmp_subversion(const uint8_t * event) {
+    return little_endian_read_16(event, 8);
+}
+
+/**
  * @brief Get field num_hci_command_packets from event HCI_EVENT_COMMAND_COMPLETE
  * @param event packet
  * @return num_hci_command_packets

--- a/src/hci_cmd.c
+++ b/src/hci_cmd.c
@@ -324,6 +324,13 @@ const hci_cmd_t hci_read_remote_supported_features_command = {
 OPCODE(OGF_LINK_CONTROL, 0x1B), "H"
 };
 
+/**
+ * @param handle
+ */
+const hci_cmd_t hci_read_remote_version_information = {
+OPCODE(OGF_LINK_CONTROL, 0x1D), "H"
+};
+
 /** 
  * @param handle
  * @param transmit_bandwidth 8000(64kbps)

--- a/src/hci_cmd.h
+++ b/src/hci_cmd.h
@@ -124,6 +124,7 @@ extern const hci_cmd_t hci_read_local_version_information;
 extern const hci_cmd_t hci_read_loopback_mode;
 extern const hci_cmd_t hci_read_num_broadcast_retransmissions;
 extern const hci_cmd_t hci_read_remote_supported_features_command;
+extern const hci_cmd_t hci_read_remote_version_information;
 extern const hci_cmd_t hci_read_rssi;
 extern const hci_cmd_t hci_reject_connection_request;
 extern const hci_cmd_t hci_remote_name_request;


### PR DESCRIPTION
This commit adds support for the HCI event
read_remote_version_information_complete