### PR TITLE
l2cap: sanity check

### DIFF
--- a/src/l2cap.c
+++ b/src/l2cap.c
@@ -1903,7 +1903,7 @@ uint8_t l2cap_create_channel(btstack_packet_handler_t channel_packet_handler, bd
 
     // check if hci connection is already usable
     hci_connection_t * conn = hci_connection_for_bd_addr_and_type(address, BD_ADDR_TYPE_CLASSIC);
-    if (conn){
+    if (conn && conn->con_handle != HCI_CON_HANDLE_INVALID){
         log_info("l2cap_create_channel, hci connection 0x%04x already exists", conn->con_handle);
         l2cap_handle_connection_complete(conn->con_handle, channel);
         // check if remote supported fearures are already received


### PR DESCRIPTION
Adds a sanity check in l2cap.

This check could be totally wrong, but I noticed that sometimes the
con_handle was 0xffff and that caused a crash while using it in esp32.