### PR TITLE
gap: add funtion to do pin pairing with pin length

### DIFF
--- a/src/gap.h
+++ b/src/gap.h
@@ -538,6 +538,15 @@ int gap_remote_name_request(bd_addr_t addr, uint8_t page_scan_repetition_mode, u
 int gap_pin_code_response(bd_addr_t addr, const char * pin);
 
 /**
+ * @brief Legacy Pairing Pin Code Response
+ * @param addr
+ * @param pin
+ * @param pin_len
+ * @return 0 if ok
+ */
+int gap_pin_code_response_with_len(bd_addr_t addr, const char * pin, uint16_t pin_len);
+
+/**
  * @brief Abort Legacy Pairing
  * @param addr
  * @param pin

--- a/src/hci.c
+++ b/src/hci.c
@@ -3299,7 +3299,7 @@ static void hci_run(void){
         hci_stack->gap_pairing_state = GAP_PAIRING_STATE_IDLE;
         switch (state){
             case GAP_PAIRING_STATE_SEND_PIN:
-                hci_send_cmd(&hci_pin_code_request_reply, hci_stack->gap_pairing_addr, strlen(hci_stack->gap_pairing_input.gap_pairing_pin), hci_stack->gap_pairing_input.gap_pairing_pin);
+                hci_send_cmd(&hci_pin_code_request_reply, hci_stack->gap_pairing_addr, hci_stack->gap_pairing_pin_len, hci_stack->gap_pairing_input.gap_pairing_pin);
                 break;
             case GAP_PAIRING_STATE_SEND_PIN_NEGATIVE:
                 hci_send_cmd(&hci_pin_code_request_negative_reply, hci_stack->gap_pairing_addr);
@@ -4891,8 +4891,17 @@ static int gap_pairing_set_state_and_run(bd_addr_t addr, uint8_t state){
 int gap_pin_code_response(bd_addr_t addr, const char * pin){
     if (hci_stack->gap_pairing_state != GAP_PAIRING_STATE_IDLE) return ERROR_CODE_COMMAND_DISALLOWED;
     hci_stack->gap_pairing_input.gap_pairing_pin = pin;
+    hci_stack->gap_pairing_pin_len = strlen(pin);
     return gap_pairing_set_state_and_run(addr, GAP_PAIRING_STATE_SEND_PIN);
 }
+
+int gap_pin_code_response_with_len(bd_addr_t addr, const char * pin, uint16_t pin_len){
+    if (hci_stack->gap_pairing_state != GAP_PAIRING_STATE_IDLE) return ERROR_CODE_COMMAND_DISALLOWED;
+    hci_stack->gap_pairing_input.gap_pairing_pin = pin;
+    hci_stack->gap_pairing_pin_len = pin_len;
+    return gap_pairing_set_state_and_run(addr, GAP_PAIRING_STATE_SEND_PIN);
+}
+
 
 /**
  * @brief Abort Legacy Pairing

--- a/src/hci.h
+++ b/src/hci.h
@@ -814,6 +814,7 @@ typedef struct {
         const char * gap_pairing_pin;
         uint32_t     gap_pairing_passkey;
     } gap_pairing_input;
+    uint16_t  gap_pairing_pin_len;
     
     uint16_t  sco_voice_setting;
     uint16_t  sco_voice_setting_active;


### PR DESCRIPTION
Some gamepads like the Nintendo Wii U Pro uses the host address as
the pin code.  And the address might contain a 0. If so, it won't be
possible to pair with a Nintendo Wii U Pro.

This patch adds support for that.