### PR TITLE
posix: use timespec for measuring time in btstack loop

### DIFF
--- a/port/libusb/Makefile
+++ b/port/libusb/Makefile
@@ -8,7 +8,7 @@ COMMON += btstack_audio_portaudio.c btstack_chipset_zephyr.c
 
 include ${BTSTACK_ROOT}/example/Makefile.inc
 
-CFLAGS  += -g -std=c99 -Wall -Wmissing-prototypes -Wstrict-prototypes -Wshadow -Wunused-parameter -Wredundant-decls -Wsign-compare
+CFLAGS  += -g -std=gnu99 -Wall -Wmissing-prototypes -Wstrict-prototypes -Wshadow -Wunused-parameter -Wredundant-decls -Wsign-compare
 # CFLAGS += -Werror
 # CFLAGS += -pedantic
 


### PR DESCRIPTION
Current timeval usage might be affected by discontinuous jumps in system time and cause timing erros.
Also, POSIX standard describes gettimeofday as obsolete.