### PR TITLE
Some fixes for Bosch XDK110 implementation

### DIFF
--- a/chipset/em9301/btstack_chipset_em9301.c
+++ b/chipset/em9301/btstack_chipset_em9301.c
@@ -53,9 +53,6 @@
 #include <string.h>   /* memcpy */
 #include "hci.h"
 
-// should go to some common place
-#define OPCODE(ogf, ocf) (ocf | ogf << 10)
-
 #define HCI_OPCODE_EM_WRITE_PATCH_START        (0xFC27)
 #define HCI_OPCODE_EM_WRITE_PATCH_CONTINUE     (0xFC28)
 #define HCI_OPCODE_EM_WRITE_PATCH_ABORT        (0xFC29)

--- a/chipset/em9301/btstack_chipset_em9301.h
+++ b/chipset/em9301/btstack_chipset_em9301.h
@@ -63,6 +63,7 @@ extern const hci_cmd_t hci_vendor_em_transmitter_test_end;
 extern const hci_cmd_t hci_vendor_em_patch_query;
 extern const hci_cmd_t hci_vendor_em_set_memory_mode;
 extern const hci_cmd_t hci_vendor_em_set_sleep_options;
+extern const hci_cmd_t hci_vendor_em_set_operating_state;
 
 #if defined __cplusplus
 }

--- a/platform/embedded/btstack_em9304_spi_embedded.c
+++ b/platform/embedded/btstack_em9304_spi_embedded.c
@@ -145,7 +145,7 @@ static void btstack_em9304_spi_embedded_set_transfer_done_callback(void (*callba
 /**
  * @brief Poll READY state
  */
-static int btstack_em9304_spi_embedded_get_ready(){
+static int btstack_em9304_spi_embedded_get_ready(void){
     return hal_em9304_spi_get_ready();
 }
 

--- a/platform/embedded/hal_em9304_spi.h
+++ b/platform/embedded/hal_em9304_spi.h
@@ -87,7 +87,7 @@ void hal_em9304_spi_disable_ready_interrupt(void);
 /**
  * @brief Poll READY state
  */
-int hal_em9304_spi_get_ready();
+int hal_em9304_spi_get_ready(void);
 
 /**
  * @brief Set Chip Selet

--- a/platform/freertos/btstack_run_loop_freertos.c
+++ b/platform/freertos/btstack_run_loop_freertos.c
@@ -52,7 +52,7 @@
 #include "btstack_linked_list.h"
 #include "btstack_debug.h"
 #include "btstack_util.h"
-#include "hal_time_ms.h"
+#include <platform/embedded/hal_time_ms.h>
 
 // some SDKs, e.g. esp-idf, place FreeRTOS headers into an 'freertos' folder to avoid name collisions (e.g. list.h, queue.h, ..)
 // wih this flag, the headers are properly found

--- a/platform/freertos/btstack_uart_block_freertos.c
+++ b/platform/freertos/btstack_uart_block_freertos.c
@@ -48,7 +48,7 @@
 #include "btstack_debug.h"
 #include "btstack_uart_block.h"
 #include "btstack_run_loop_freertos.h"
-#include "hal_uart_dma.h"
+#include <platform/embedded/hal_uart_dma.h>
 
 #ifdef HAVE_FREERTOS_INCLUDE_PREFIX
 #include "freertos/FreeRTOS.h"

--- a/src/bluetooth.h
+++ b/src/bluetooth.h
@@ -380,7 +380,7 @@ typedef enum {
 #define OGF_LE_CONTROLLER 0x08
 #define OGF_VENDOR  0x3f
 
-
+#define OPCODE(ogf, ocf) ((ocf) | ((ogf) << 10))
 
 
 /** 

--- a/src/hci_transport_h5.c
+++ b/src/hci_transport_h5.c
@@ -738,7 +738,7 @@ static void hci_transport_h5_read_next_byte(void){
 
 // track time receiving SLIP frame
 static uint32_t hci_transport_h5_receive_start;
-static void hci_transport_h5_block_received(){
+static void hci_transport_h5_block_received(void){
     if (hci_transport_h5_active == 0) return;
 
     // track start time when receiving first byte // a bit hackish


### PR DESCRIPTION
I make the OPCODE macro global available and modified the commands in em9301 chipset.
Fixed some prototype errors.
Modified some HAL includes in FreeRTOS -> should be checked.