### PR TITLE
tool/compile_gatt.py: Open temp file in text mode.

### DIFF
--- a/tool/compile_gatt.py
+++ b/tool/compile_gatt.py
@@ -1018,7 +1018,7 @@ try:
     fin  = codecs.open (args.gattfile, encoding='utf-8')
 
     # pass 1: create temp .h file
-    ftemp = tempfile.TemporaryFile()
+    ftemp = tempfile.TemporaryFile(mode='w+')
     parse(args.gattfile, fin, filename, sys.argv[0], ftemp)
     listHandles(ftemp)
 


### PR DESCRIPTION
This script fails otherwise because it's attempting to write `str` values not `bytes` to the file.