### PR TITLE
hci.c: Allow btstack_config to change the HCI reset timeout.

### DIFF
--- a/port/libusb/btstack_config.h
+++ b/port/libusb/btstack_config.h
@@ -51,5 +51,8 @@
 // allow for one NetKey update
 #define MAX_NR_MESH_NETWORK_KEYS      (MAX_NR_MESH_SUBNETS+1)
 
+// Some USB dongles take longer to respond to HCI reset (e.g. BCM20702A).
+#define HCI_RESET_RESEND_TIMEOUT_MS   500
+
 #endif
 

--- a/src/hci.c
+++ b/src/hci.c
@@ -94,7 +94,10 @@
 #endif
 
 #define HCI_CONNECTION_TIMEOUT_MS 10000
+
+#ifndef HCI_RESET_RESEND_TIMEOUT_MS
 #define HCI_RESET_RESEND_TIMEOUT_MS 200
+#endif
 
 // Names are arbitrarily shortened to 32 bytes if not requested otherwise
 #ifndef GAP_INQUIRY_MAX_NAME_LEN


### PR DESCRIPTION
I have been testing with a "Targus BT 4.0 dongle" which has a BCM20702A. I notice that it frequently gets into a state where it never responds to the HCI reset during initialization.

Easy way to repro this issue is to run the `gatt_counter` demo in `port/libusb`. Every second time I run it it never gets past the "USB Path: 02-02" line and if I enable hci dump to stdout, it looks like:

```
USB Path: 02-02
[2020-04-07 13:53:12.771] LOG -- hci_transport_h2_libusb.c.738: libusb_detach_kernel_driver
[2020-04-07 13:53:12.771] LOG -- hci_transport_h2_libusb.c.742: setting configuration 1...
[2020-04-07 13:53:12.771] LOG -- hci_transport_h2_libusb.c.754: claiming interface 0...
[2020-04-07 13:53:12.771] LOG -- hci_transport_h2_libusb.c.766: claiming interface 1...
[2020-04-07 13:53:12.771] LOG -- hci_transport_h2_libusb.c.619: active configuration has 4 interfaces
[2020-04-07 13:53:12.771] LOG -- hci_transport_h2_libusb.c.625: interface 0: 3 endpoints
[2020-04-07 13:53:12.771] LOG -- hci_transport_h2_libusb.c.630: - endpoint 81, attributes 3
[2020-04-07 13:53:12.771] LOG -- hci_transport_h2_libusb.c.636: -> using 0x81 for HCI Events
[2020-04-07 13:53:12.772] LOG -- hci_transport_h2_libusb.c.630: - endpoint 82, attributes 2
[2020-04-07 13:53:12.772] LOG -- hci_transport_h2_libusb.c.642: -> using 0x82 for ACL Data In
[2020-04-07 13:53:12.772] LOG -- hci_transport_h2_libusb.c.630: - endpoint 2, attributes 2
[2020-04-07 13:53:12.772] LOG -- hci_transport_h2_libusb.c.646: -> using 0x02 for ACL Data Out
[2020-04-07 13:53:12.772] LOG -- hci_transport_h2_libusb.c.625: interface 1: 2 endpoints
[2020-04-07 13:53:12.772] LOG -- hci_transport_h2_libusb.c.630: - endpoint 83, attributes 1
[2020-04-07 13:53:12.772] LOG -- hci_transport_h2_libusb.c.653: -> using 0x83 for SCO Data In
[2020-04-07 13:53:12.772] LOG -- hci_transport_h2_libusb.c.630: - endpoint 3, attributes 1
[2020-04-07 13:53:12.772] LOG -- hci_transport_h2_libusb.c.657: -> using 0x03 for SCO Data Out
[2020-04-07 13:53:12.772] LOG -- hci_transport_h2_libusb.c.625: interface 2: 2 endpoints
[2020-04-07 13:53:12.772] LOG -- hci_transport_h2_libusb.c.630: - endpoint 84, attributes 2
[2020-04-07 13:53:12.772] LOG -- hci_transport_h2_libusb.c.630: - endpoint 4, attributes 2
[2020-04-07 13:53:12.772] LOG -- hci_transport_h2_libusb.c.625: interface 3: 0 endpoints
[2020-04-07 13:53:12.772] LOG -- hci_transport_h2_libusb.c.1141: Async using timers:
[2020-04-07 13:53:12.772] LOG -- hci.c.4288: BTSTACK_EVENT_STATE 1
[2020-04-07 13:53:12.772] EVT <= 60 01 01 
[2020-04-07 13:53:12.772] LOG -- btstack_crypto.c.1061: BTSTACK_EVENT_STATE
[2020-04-07 13:53:12.772] CMD => 03 0C 00 
[2020-04-07 13:53:12.772] LOG -- btstack_run_loop_posix.c.208: POSIX run loop with monotonic clock
[2020-04-07 13:53:12.773] EVT <= 6E 00 
[2020-04-07 13:53:12.973] LOG -- hci.c.1152: Resend HCI Reset
[2020-04-07 13:53:12.973] CMD => 03 0C 00 
[2020-04-07 13:53:12.974] EVT <= 6E 00 
[2020-04-07 13:53:13.173] LOG -- hci.c.1152: Resend HCI Reset
[2020-04-07 13:53:13.173] CMD => 03 0C 00 
[2020-04-07 13:53:13.174] EVT <= 6E 00 
...
```

By increasing the timeout to 500ms it works every time.

Not sure if you'd want to change this by default, so making it a btstack_config.h option and selectively enabling for the libusb port.