### PR TITLE
Fix avdtp_si2str accessing indices out of bounds

### DIFF
--- a/src/classic/avdtp_util.c
+++ b/src/classic/avdtp_util.c
@@ -66,7 +66,7 @@ static const char * avdtp_si_name[] = {
     "AVDTP_SI_DELAY_REPORT" 
 };
 const char * avdtp_si2str(uint16_t index){
-    if ((index <= 0) || (index > sizeof(avdtp_si_name))) return avdtp_si_name[0];
+    if ((index <= 0) || (index > sizeof(avdtp_si_name)/sizeof(avdtp_si_name[0]) )) return avdtp_si_name[0];
     return avdtp_si_name[index];
 }
 


### PR DESCRIPTION
There are 14 elements in avdtp_si_name, but sizeof(avdtp_si_name) returns 14\*pointersize (in my case 14\*8).
It is thus divided by sizeof(avdtp_si_name[0]), the size of one of the pointers.