### PR TITLE
Fix some python3 related errors during compilation

### DIFF
--- a/example/Makefile.inc
+++ b/example/Makefile.inc
@@ -288,7 +288,7 @@ default_target: all
 
 # compile .gatt descriptions
 %.h: %.gatt
-	python ${BTSTACK_ROOT}/tool/compile_gatt.py $< $@
+	python3 ${BTSTACK_ROOT}/tool/compile_gatt.py $< $@
 
 # examples
 ant_test: ${CORE_OBJ} ${COMMON_OBJ} ${CLASSIC_OBJ} ant_test.c

--- a/port/qt-h4/CMakeLists.txt
+++ b/port/qt-h4/CMakeLists.txt
@@ -14,10 +14,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 message("${Qt5_DIR}")
 
 find_package(Qt5Core)
-include(FindPythonInterp)
+find_package(FindPython3)
 
 # BTstack Root
-set(BTSTACK_ROOT "../..")
+set(BTSTACK_ROOT "${PROJECT_SOURCE_DIR}/../..")
 message("BTSTACK_ROOT: ${BTSTACK_ROOT}")
 
 # BTstack include

--- a/tool/compile_gatt.py
+++ b/tool/compile_gatt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # BLE GATT configuration generator for use with BTstack
 # Copyright 2019 BlueKitchen GmbH


### PR DESCRIPTION
* qt-h4 cmake now uses PROJECT_SOURCE_DIR to correctly point to the project root folder (fixes compilation error when the user build from sub-folder)
* Change from using python to `python3` (previously compilation would fail if user had python as the default python2.7)

@mringwal  Let me know what you think as this fix is not exhaustive. It should give an idea of why explicitly use python3 instead of python. (to avoid compilation errors due to difference in pycryptodomex for python2.7).