### PR TITLE
posix: fix mismatch index i

### DIFF
--- a/platform/posix/btstack_run_loop_posix.c
+++ b/platform/posix/btstack_run_loop_posix.c
@@ -126,7 +126,7 @@ static void btstack_run_loop_posix_dump_timer(void){
     int i = 0;
     for (it = (btstack_linked_item_t *) timers; it ; it = it->next){
         btstack_timer_source_t *ts = (btstack_timer_source_t*) it;
-        log_info("timer %u (%p): timeout %u\n", i, ts, ts->timeout);
+        log_info("timer %u (%p): timeout %u\n", i++, ts, ts->timeout);
     }
 }
 


### PR DESCRIPTION
if i is always 0,then it maybe mismatch with the index meaning,so i add 1 to i with each item.