### PR TITLE
Fix compile error when ENABLE_LE_CENTRAL is not set

### DIFF
--- a/src/ble/sm.c
+++ b/src/ble/sm.c
@@ -3819,8 +3819,10 @@ static void sm_pdu_handler(uint8_t packet_type, hci_con_handle_t con_handle, uin
         return;
     }
 
+#ifdef ENABLE_LE_CENTRAL
     int have_ltk;
     uint8_t ltk[16];
+#endif
 
     switch (sm_conn->sm_engine_state){
 


### PR DESCRIPTION
This fixes the following errors when ENABLE_LE_CENTRAL is not enabled:

    ../../lib/btstack/src/ble/sm.c: In function 'sm_pdu_handler':
    ../../lib/btstack/src/ble/sm.c:3823:13: error: unused variable 'ltk' [-Werror=unused-variable]
    3823 |     uint8_t ltk[16];
        |             ^~~
    ../../lib/btstack/src/ble/sm.c:3822:9: error: unused variable 'have_ltk' [-Werror=unused-variable]
    3822 |     int have_ltk;
        |         ^~~~~~~~