### PR TITLE
segment fault occur when run example in windows-winusb and windows-winusb-intel

### DIFF
--- a/port/windows-winusb-intel/main.c
+++ b/port/windows-winusb-intel/main.c
@@ -64,7 +64,7 @@
 #include "hci_dump.h"
 #include "hci_dump_posix_fs.h"
 #include "hci_transport.h"
-#include "hci_transport_h4.h"
+#include "hci_transport_usb.h"
 #include "btstack_stdin.h"
 #include "btstack_chipset_intel_firmware.h"
 

--- a/port/windows-winusb/main.c
+++ b/port/windows-winusb/main.c
@@ -64,7 +64,7 @@
 #include "hci_dump.h"
 #include "hci_dump_posix_fs.h"
 #include "hci_transport.h"
-#include "hci_transport_h4.h"
+#include "hci_transport_usb.h"
 #include "btstack_stdin.h"
 
 int btstack_main(int argc, const char * argv[]);


### PR DESCRIPTION
bug : segment fault occur when run example in windows-winusb and windows-winusb-intel;
rootcase : link improper function due to include improper head file in main.c, then return improper address from hci_transport_usb_instance();
solution:modify include head file from #include "hci_transport_h4.h" to #include "hci_transport_usb.h"
