### PR TITLE
esp32: update CMakeLists.txt file

### DIFF
--- a/port/esp32/components/btstack/CMakeLists.txt
+++ b/port/esp32/components/btstack/CMakeLists.txt
@@ -1,46 +1,56 @@
-set(COMPONENT_ADD_INCLUDEDIRS "3rd-party/bluedroid/decoder/include"
-                              "3rd-party/bluedroid/encoder/include"
-                              "3rd-party/hxcmod-player"
-                              "3rd-party/hxcmod-player/mods"
-                              "../lwip/lwip/src/include"
-                              "3rd-party/lwip/dhcp-server"
-                              "3rd-party/md5"
-                              "3rd-party/yxml"
-                              "src/classic"
-                              "src/ble/gatt-service"
-                              "src/ble"
-                              "src/classic"
-                              "src"
-                              "platform/embedded"
-                              "platform/freertos"
-                              "platform/lwip"
-                              "include")
+# Needed to include the lwIP's HTTP app, which is not included by default.
+set(IDF_PATH $ENV{IDF_PATH})
 
-set(COMPONENT_SRCDIRS "3rd-party/bluedroid/decoder/srce"
-                      "3rd-party/bluedroid/encoder/srce"
-                      "3rd-party/hxcmod-player"
-                      "3rd-party/hxcmod-player/mods"
-                      "../lwip/lwip/src/apps/http"
-                      "3rd-party/md5"
-                      "3rd-party/yxml"
-                      "3rd-party/micro-ecc"
-                      "3rd-party/lwip/dhcp-server"
-                      "src/ble/gatt-service"
-                      "src/ble"
-                      "src/classic"
-                      "src/mesh"
-                      "src/"
-                      "platform/freertos"
-                      "platform/lwip"
-                      ".")
+if (CMAKE_HOST_WIN32)
+    string(REPLACE "\\" "/" IDF_PATH $ENV{IDF_PATH})
+endif()
 
-set(COMPONENT_PRIV_INCLUDEDIRS
+set(include_dirs "3rd-party/bluedroid/decoder/include"
+                 "3rd-party/bluedroid/encoder/include"
+                 "3rd-party/hxcmod-player"
+                 "3rd-party/hxcmod-player/mods"
+                 "${IDF_PATH}/components/lwip/lwip/src/include"
+                 "3rd-party/lwip/dhcp-server"
+                 "3rd-party/md5"
+                 "3rd-party/yxml"
+                 "src/classic"
+                 "src/ble/gatt-service"
+                 "src/ble"
+                 "src/classic"
+                 "src"
+                 "platform/embedded"
+                 "platform/freertos"
+                 "platform/lwip"
+                 "include")
+
+set(src_dirs "3rd-party/bluedroid/decoder/srce"
+             "3rd-party/bluedroid/encoder/srce"
+             "3rd-party/hxcmod-player"
+             "3rd-party/hxcmod-player/mods"
+             "${IDF_PATH}/components/lwip/lwip/src/apps/http"
+             "3rd-party/md5"
+             "3rd-party/micro-ecc"
+             "3rd-party/lwip/dhcp-server"
+             "src/ble/gatt-service"
+             "src/ble"
+             "src/classic"
+             "src/mesh"
+             "src/"
+             "platform/freertos"
+             "platform/lwip"
+             ".")
+
+set(priv_include_dirs
         "3rd-party/micro-ecc"
         )
 
-set(COMPONENT_PRIV_REQUIRES
+set(priv_requires
         "nvs_flash"
         "bt"
+        "lwip"
         )
 
-register_component()
+idf_component_register(SRC_DIRS "${src_dirs}"
+                    INCLUDE_DIRS "${include_dirs}"
+                    PRIV_INCLUDE_DIRS "${priv_include_dirs}"
+                    PRIV_REQUIRES ${priv_requires})


### PR DESCRIPTION
This commit updates the esp32 CMakeLists.txt so that it is compatible
with the new way of creating CMakeLists.txt files in ESP-IDF.

Basically it replaces the old register_component() with
idf_component_register().

It also removes the relative references to lwip. This is because some
projects might want to puse btstack directly in their private "components"
folder (instead of being placed in the esp-idf/component folder)

It has been tested both by:
 - placing btstack in esp-idf/components
 - placing btstack in my_own_project/components

 and it compiled Ok using "idf.py build"