### PR TITLE
libusb: Do not detach kernel driver on Cygwin

### DIFF
--- a/platform/libusb/hci_transport_h2_libusb.c
+++ b/platform/libusb/hci_transport_h2_libusb.c
@@ -722,7 +722,7 @@ static int prepare_device(libusb_device_handle * aHandle){
     int kernel_driver_detached = 0;
 
     // Detach OS driver (not possible for OS X, FreeBSD, and WIN32)
-#if !defined(__APPLE__) && !defined(_WIN32) && !defined(__FreeBSD__)
+#if !defined(__APPLE__) && !defined(_WIN32) && !defined(__CYGWIN__) && !defined(__FreeBSD__)
     r = libusb_kernel_driver_active(aHandle, 0);
     if (r < 0) {
         log_error("libusb_kernel_driver_active error %d", r);


### PR DESCRIPTION
Since Cygwin uses Windows kernel and driver stack, libusb limitation on Windows is inherited there.

Other `#if defined(_WIN32)` locations are okay to left as-is; Cygwin provides decent POSIX emulation and it should work flawlessly.

Confirmed working with Win10 Enterprise 20H1 + Cygwin 3.3.2 + libusb 1.0.21-1 + `0a12:0001 Cambridge Silicon Radio, Ltd Bluetooth Dongle` + Nordic SPP streamer sample(BLE).