### PR TITLE
safely removed hfp_connect->command = HFP_CMD_NODE

### DIFF
--- a/src/classic/hfp.c
+++ b/src/classic/hfp.c
@@ -524,7 +524,6 @@ void hfp_reset_context_flags(hfp_connection_t * hfp_connection){
 
     hfp_connection->establish_audio_connection = 0; 
     hfp_connection->call_waiting_notification_enabled = 0;
-    hfp_connection->command = HFP_CMD_NONE;
     hfp_connection->enable_status_update_for_ag_indicators = 0xFF;
 }
 

--- a/src/classic/hfp.c
+++ b/src/classic/hfp.c
@@ -524,6 +524,7 @@ void hfp_reset_context_flags(hfp_connection_t * hfp_connection){
 
     hfp_connection->establish_audio_connection = 0; 
     hfp_connection->call_waiting_notification_enabled = 0;
+    hfp_connection->command = HFP_CMD_NONE;
     hfp_connection->enable_status_update_for_ag_indicators = 0xFF;
 }
 
@@ -536,7 +537,6 @@ static hfp_connection_t * create_hfp_connection_context(void){
     hfp_connection->codecs_state = HFP_CODECS_IDLE;
 
     hfp_connection->parser_state = HFP_PARSER_CMD_HEADER;
-    hfp_connection->command = HFP_CMD_NONE;
     
     hfp_connection->acl_handle = HCI_CON_HANDLE_INVALID;
     hfp_connection->sco_handle = HCI_CON_HANDLE_INVALID;

--- a/src/classic/hfp_hf.c
+++ b/src/classic/hfp_hf.c
@@ -1124,7 +1124,6 @@ static void hfp_hf_handle_rfcomm_command(hfp_connection_t * hfp_connection){
         case HFP_CMD_ERROR:
             hfp_connection->ok_pending = 0;
             hfp_reset_context_flags(hfp_connection);
-            hfp_connection->command = HFP_CMD_NONE;
 
             switch (hfp_connection->state){
                 case HFP_SERVICE_LEVEL_CONNECTION_ESTABLISHED:


### PR DESCRIPTION
hfp_connectio->command safelv removed from create_hfp_connection_context.

Signed-off-by: ym597061128@gmail.com