### PR TITLE
HCI: Add periodic inquiry mode command

### DIFF
--- a/src/hci_cmd.c
+++ b/src/hci_cmd.c
@@ -308,6 +308,23 @@ const hci_cmd_t hci_inquiry_cancel = {
 };
 
 /**
+ * @param max_period_length
+ * @param min_period_length
+ * @param lap
+ * @param inquiry_length
+ * @param num_responses
+ */
+const hci_cmd_t hci_periodic_inquiry_mode = {
+    HCI_OPCODE_HCI_PERIODIC_INQUIRY_MODE, "22311"
+};
+
+/**
+ */
+const hci_cmd_t hci_exit_periodic_inquiry_mode = {
+    HCI_OPCODE_HCI_EXIT_PERIODIC_INQUIRY_MODE, ""
+};
+
+/**
  * @param bd_addr
  * @param packet_type
  * @param page_scan_repetition_mode

--- a/src/hci_cmd.h
+++ b/src/hci_cmd.h
@@ -90,6 +90,8 @@ typedef enum {
     // Link Control
     HCI_OPCODE_HCI_INQUIRY = HCI_OPCODE (OGF_LINK_CONTROL, 0x01),
     HCI_OPCODE_HCI_INQUIRY_CANCEL = HCI_OPCODE (OGF_LINK_CONTROL, 0x02),
+    HCI_OPCODE_HCI_PERIODIC_INQUIRY_MODE = HCI_OPCODE(OGF_LINK_CONTROL, 0x03),
+    HCI_OPCODE_HCI_EXIT_PERIODIC_INQUIRY_MODE = HCI_OPCODE(OGF_LINK_CONTROL, 0x04),
     HCI_OPCODE_HCI_CREATE_CONNECTION = HCI_OPCODE (OGF_LINK_CONTROL, 0x05),
     HCI_OPCODE_HCI_DISCONNECT = HCI_OPCODE (OGF_LINK_CONTROL, 0x06),
     HCI_OPCODE_HCI_CREATE_CONNECTION_CANCEL = HCI_OPCODE (OGF_LINK_CONTROL, 0x08),
@@ -357,6 +359,8 @@ extern const hci_cmd_t hci_link_key_request_negative_reply;
 extern const hci_cmd_t hci_link_key_request_reply;
 extern const hci_cmd_t hci_park_state;
 extern const hci_cmd_t hci_exit_park_state;
+extern const hci_cmd_t hci_periodic_inquiry_mode;
+extern const hci_cmd_t hci_exit_periodic_inquiry_mode;
 extern const hci_cmd_t hci_pin_code_request_negative_reply;
 extern const hci_cmd_t hci_pin_code_request_reply;
 extern const hci_cmd_t hci_qos_setup;


### PR DESCRIPTION
This commit adds the HCI periodic inquiry mode command.
It is part of the Core spec defined in "Link Control" secion with the
name "7.1.3 Periodic Inquiry Mode Command"

It was tested with:
 hci_send_cmd(&hci_periodic_inquiry_mode, 5, 4, GAP_IAC_GENERAL_INQUIRY,
              2, 0);

And then verified the dump with Wireshark and the command was sent as
expected.