### PR TITLE
Pan fix dhcp server interface

### DIFF
--- a/3rd-party/lwip/dhcp-server/dhserver.c
+++ b/3rd-party/lwip/dhcp-server/dhserver.c
@@ -231,6 +231,7 @@ static void udp_recv_proc(void *arg, struct udp_pcb *upcb, struct pbuf *p, const
 	uint8_t *ptr;
 	dhcp_entry_t *entry;
 	struct pbuf *pp;
+	struct netif *nif;
 
 	unsigned int n = p->len;
 	if (n > sizeof(dhcp_data)) n = sizeof(dhcp_data);
@@ -262,7 +263,12 @@ static void udp_recv_proc(void *arg, struct udp_pcb *upcb, struct pbuf *p, const
 			pp = pbuf_alloc(PBUF_TRANSPORT, sizeof(dhcp_data), PBUF_POOL);
 			if (pp == NULL) break;
 			memcpy(pp->payload, &dhcp_data, sizeof(dhcp_data));
-			udp_sendto(upcb, pp, IP_ADDR_BROADCAST, port);
+			nif = ip_current_input_netif();
+			if (nif) {
+				udp_sendto_if(upcb, pp, IP_ADDR_BROADCAST, port, nif);
+			} else {
+				udp_sendto(upcb, pp, IP_ADDR_BROADCAST, port);
+			}
 			pbuf_free(pp);
 			break;
 
@@ -306,7 +312,12 @@ static void udp_recv_proc(void *arg, struct udp_pcb *upcb, struct pbuf *p, const
 			if (pp == NULL) break;
 			memcpy(entry->mac, dhcp_data.dp_chaddr, 6);
 			memcpy(pp->payload, &dhcp_data, sizeof(dhcp_data));
-			udp_sendto(upcb, pp, IP_ADDR_BROADCAST, port);
+			nif = ip_current_input_netif();
+			if (nif) {
+				udp_sendto_if(upcb, pp, IP_ADDR_BROADCAST, port, nif);
+			} else {
+				udp_sendto(upcb, pp, IP_ADDR_BROADCAST, port);
+			}
 			pbuf_free(pp);
 			break;
 


### PR DESCRIPTION
While testing PAN I had an issue with my PC using the wrong address for the PAN network. It wasn't getting the DHCP server replies so was using some random address. This was caused by having another wifi network interface connected on the device at the same time. It was added later and had changed the default interface used for sending data.

I expect everything to route data correctly when IP addresses are assigned, so we just need to make sure the DHCP server sends it's replies on the right network. Add accessors for getting the interface from bnep and setting it in the dhcp server. Then fix this up in the PAN example. I can see from logging in the DHCP server and lease details on my PC that this works as expected.