### PR TITLE
btstack_uart: add missing __cplusplus judgment

### DIFF
--- a/src/btstack_uart.h
+++ b/src/btstack_uart.h
@@ -48,6 +48,10 @@
 #include <stdint.h>
 #include "btstack_config.h"
 
+#if defined __cplusplus
+extern "C" {
+#endif
+
 #define BTSTACK_UART_PARITY_OFF  0
 #define BTSTACK_UART_PARITY_EVEN 1
 #define BTSTACK_UART_PARITY_ODD  2
@@ -183,5 +187,9 @@ typedef struct {
 
 // common implementations
 const btstack_uart_t * btstack_uart_posix_instance(void);
+
+#if defined __cplusplus
+}
+#endif
 
 #endif

--- a/src/btstack_uart_slip_wrapper.h
+++ b/src/btstack_uart_slip_wrapper.h
@@ -51,6 +51,10 @@
 #include <stdint.h>
 #include "btstack_uart.h"
 
+#if defined __cplusplus
+extern "C" {
+#endif
+
 /* API_START */
 
 /**
@@ -61,5 +65,9 @@
 const btstack_uart_t * btstack_uart_slip_wrapper_instance(const btstack_uart_t * uart_without_slip);
 
 /* API_END */
+
+#if defined __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
Fix the compilation error caused by C++ include the header file.