### PR TITLE
fix `compile_gatt.py` emitting incorrect descriptor blob for `VALID_RANGE` and `ENVIRONMENTAL_SENSING_MEASUREMENT`

### DIFF
--- a/tool/compile_gatt.py
+++ b/tool/compile_gatt.py
@@ -714,7 +714,7 @@ def parseGenericDynamicReadOnlyDescriptor(fout, parts, uuid, name):
     write_16(fout, size)
     write_16(fout, flags)
     write_16(fout, handle)
-    write_16(fout, 0x2903)
+    write_16(fout, uuid)
     fout.write("\n")
 
     database_hash_append_uint16(handle)


### PR DESCRIPTION
Using a `VALID_RANGE` (0x2906) or `ENVIRONMENTAL_SENSING_MEASUREMENT` (0x290C) characteristic attribute results in a incorrect descriptor blob specifying `SERVER_CHARACTERISTIC_CONFIGURATION` (0x2903) instead of the correct short UUIDs.

Cause:
`parseGenericDynamicDescriptor` in `compile_gatt.py` emits hard coded 0x2903 instead of `uuid` parameter.

Example:

demo.gatt:
```
PRIMARY_SERVICE, ORG_BLUETOOTH_SERVICE_ENVIRONMENTAL_SENSING
CHARACTERISTIC, ORG_BLUETOOTH_CHARACTERISTIC_TEMPERATURE, READ
ENVIRONMENTAL_SENSING_MEASUREMENT, READ
```

produces:
```
const uint8_t profile_data[] =
{
    // ATT DB Version
    1,

    // 0x0001 PRIMARY_SERVICE-ORG_BLUETOOTH_SERVICE_ENVIRONMENTAL_SENSING
    0x0a, 0x00, 0x02, 0x00, 0x01, 0x00, 0x00, 0x28, 0x1a, 0x18, 
    // 0x0002 CHARACTERISTIC-ORG_BLUETOOTH_CHARACTERISTIC_TEMPERATURE - READ
    0x0d, 0x00, 0x02, 0x00, 0x02, 0x00, 0x03, 0x28, 0x02, 0x03, 0x00, 0x6e, 0x2a, 
    // 0x0003 VALUE CHARACTERISTIC-ORG_BLUETOOTH_CHARACTERISTIC_TEMPERATURE - READ -''
    // READ_ANYBODY
    0x08, 0x00, 0x02, 0x00, 0x03, 0x00, 0x6e, 0x2a, 
    // 0x0004 ENVIRONMENTAL_SENSING_MEASUREMENT-READ
    // READ_ANYBODY
    0x08, 0x00, 0x02, 0x01, 0x04, 0x00, 0x03, 0x29, // <-- Here. 0x03 0x29, instead of 0x0c 0x29
    // END
    0x00, 0x00, 
}; // total size 25 bytes 
```
