### PR TITLE
fix of advertisement name mismatch in LE client examples

### DIFF
--- a/example/le_credit_based_flow_control_mode_client.c
+++ b/example/le_credit_based_flow_control_mode_client.c
@@ -146,7 +146,7 @@ static int advertisement_report_contains_name(const char * name, uint8_t * adver
                 // compare prefix
                 if (data_size < name_len) break;
                 if (memcmp(data, name, name_len) == 0) return 1;
-                return 1;
+                return 0;
             default:
                 break;
         }

--- a/example/le_streamer_client.c
+++ b/example/le_streamer_client.c
@@ -198,7 +198,7 @@ static int advertisement_contains_name(const char * name, uint8_t adv_len, const
                 // compare prefix
                 if (data_size < name_len) break;
                 if (memcmp(data, name, name_len) == 0) return 1;
-                return 1;
+                return 0;
             default:
                 break;
         }


### PR DESCRIPTION
supersedes #472 
target branch change from 'master' to 'develop'