### PR TITLE
btstack_hid_parser: fix the report id matching logic of hid_descriptor

### DIFF
--- a/src/btstack_hid_parser.c
+++ b/src/btstack_hid_parser.c
@@ -445,7 +445,6 @@ int btstack_hid_get_report_size_for_id(int report_id, hid_report_type_t report_t
                         report_count = item.item_value;
                         break;
                     case ReportSize:
-                        if (current_report_id != report_id) break;
                         report_size = item.item_value;
                         break;
                     default:
@@ -478,6 +477,10 @@ int btstack_hid_get_report_size_for_id(int report_id, hid_report_type_t report_t
             default:
                 break;
         }
+
+        if (total_report_size > 0)
+            break;
+
         hid_descriptor_len -= item.item_size;
         hid_descriptor += item.item_size;
     }


### PR DESCRIPTION
The report size in the hid_descriptor could be reused by next report id.
And if a match found we should break the loop and return.
It will speed up a bit for big size hid_descriptor.

An example here:
http://eleccelerator.com/wiki/index.php?title=DualShock_4
The report size is defined once if not changed for the next.