### PR TITLE
hci: fix LE_SET_PHY phy_options size

### DIFF
--- a/src/hci_cmd.c
+++ b/src/hci_cmd.c
@@ -1645,7 +1645,7 @@ const hci_cmd_t hci_le_set_default_phy = {
  * @param phy_options
  */
 const hci_cmd_t hci_le_set_phy = {
-    HCI_OPCODE_HCI_LE_SET_PHY, "H1111"
+    HCI_OPCODE_HCI_LE_SET_PHY, "H1112"
 // LE PHY Update Complete is generated on completion
 };
 


### PR DESCRIPTION
**Problem**: When sending HCI_LE_SET_PHY command controller responds with 'Unsupported Feature or Parameter Value (0x11)'. Wireshark is also complaining about the command structure

> Frame 419: 10 bytes on wire (80 bits), 10 bytes captured (80 bits)
Bluetooth
PacketLogger HCI Command
    Type: HCI Command (0x00)
Bluetooth HCI Command - LE Set PHY
    Command Opcode: LE Set PHY (0x2032)
    Parameter Total Length: 6
    Connection Handle: 0x0080
    All PHYs: 0x00
        0000 00.. = Reserved: 0x00
        .... ..0. = The Host has no Rx PHY preference: False
        .... ...0 = The Host has no Tx PHY preference: False
    Tx PHYs: 0x04, The Host prefers LE Coded
        0000 0... = Reserved: 0x00
        .... .1.. = The Host prefers LE Coded: True
        .... ..0. = The Host prefers LE 2M: False
        .... ...0 = The Host prefers LE 1M: False
    Rx PHYs: 0x04, The Host prefers LE Coded
        0000 0... = Reserved: 0x00
        .... .1.. = The Host prefers LE Coded: True
        .... ..0. = The Host prefers LE 2M: False
        .... ...0 = The Host prefers LE 1M: False
[Malformed Packet: HCI_CMD]
    [Expert Info (Error/Malformed): Malformed Packet (Exception occurred)]

> Frame 421: 7 bytes on wire (56 bits), 7 bytes captured (56 bits)
Bluetooth
PacketLogger HCI Event
    Type: HCI Event (0x01)
Bluetooth HCI Event - Command Status
    Event Code: Command Status (0x0f)
    Parameter Total Length: 4
    Status: Unsupported Feature or Parameter Value (0x11)
    Number of Allowed Command Packets: 1
    Command Opcode: LE Set PHY (0x2032)
        0010 00.. .... .... = Opcode Group Field: LE Controller Commands (0x08)
        .... ..00 0011 0010 = Opcode Command Field: LE Set PHY (0x032)
    [Command in frame: 419]
    [Command-Response Delta: 15,957]



According to BLUETOOTH CORE SPECIFICATION Version 5.2 | Vol 4, Part E  7.8.49 LE Set PHY command  PHY_Options field has 2 octets


**How to reproduce** : you may use e.g. gap_le_set_phy  to send the command, e.g. in handling HCI_SUBEVENT_LE_CONNECTION_COMPLETE event.  Then collect the packet log and analyze.


**Fix**: correct PHY_Options size


***How to verify**: redo the test and check the command status

> Frame 304: 7 bytes on wire (56 bits), 7 bytes captured (56 bits)
Bluetooth
PacketLogger HCI Event
    Type: HCI Event (0x01)
Bluetooth HCI Event - Command Status
    Event Code: Command Status (0x0f)
    Parameter Total Length: 4
    Status: Pending (0x00)
    Number of Allowed Command Packets: 1
    Command Opcode: LE Set PHY (0x2032)
        0010 00.. .... .... = Opcode Group Field: LE Controller Commands (0x08)
        .... ..00 0011 0010 = Opcode Command Field: LE Set PHY (0x032)
    [Command in frame: 301]
    [Command-Pending Delta: 15,883]

