### PR TITLE
Optional optimisation for SDP records.

### DIFF
--- a/src/classic/sdp_util.h
+++ b/src/classic/sdp_util.h
@@ -121,6 +121,8 @@ void      de_add_uuid128(uint8_t * seq, uint8_t * uuid);
 // returns data element  len if date element is smaller than size
 uint32_t de_get_len_safe(const uint8_t * header, uint32_t size);
 
+uint32_t de_optimise(uint8_t* element);
+
 // MARK: DES iterator
 typedef struct {
     uint8_t * element;


### PR DESCRIPTION
By default all data sequences created by btstack use a 16bit variable for the size of the following data, however often an 8bit variable can fit the size value. This function can be used to optionally optimise the sdp record by replacing 16bit size variables with 8bit size variables. This can save storage space and reduce data sent during service discovery. It is not a huge saving, approx 5-10%, but may be worthwhile for some.