### PR TITLE
btstack_hid_parser: fix the report id matching logic of hid_descriptor PROPER

### DIFF
--- a/src/btstack_hid_parser.c
+++ b/src/btstack_hid_parser.c
@@ -441,11 +441,9 @@ int btstack_hid_get_report_size_for_id(int report_id, hid_report_type_t report_t
                         current_report_id = item.item_value;
                         break;
                     case ReportCount:
-                        if (current_report_id != report_id) break;
                         report_count = item.item_value;
                         break;
                     case ReportSize:
-                        if (current_report_id != report_id) break;
                         report_size = item.item_value;
                         break;
                     default:
@@ -472,12 +470,11 @@ int btstack_hid_get_report_size_for_id(int report_id, hid_report_type_t report_t
                 }
                 if (!valid_report_type) break;
                 total_report_size += report_count * report_size;
-                report_size = 0;
-                report_count = 0;
                 break;
             default:
                 break;
         }
+		if (total_report_size > 0 && current_report_id != report_id) break;
         hid_descriptor_len -= item.item_size;
         hid_descriptor += item.item_size;
     }

--- a/src/btstack_hid_parser.c
+++ b/src/btstack_hid_parser.c
@@ -474,7 +474,7 @@ int btstack_hid_get_report_size_for_id(int report_id, hid_report_type_t report_t
             default:
                 break;
         }
-		if (total_report_size > 0 && current_report_id != report_id) break;
+        if (total_report_size > 0 && current_report_id != report_id) break;
         hid_descriptor_len -= item.item_size;
         hid_descriptor += item.item_size;
     }


### PR DESCRIPTION
PR #496 by sunnyqeen does a partial fix for this issue by retaining the global value of report size, however my fix also retains the value for report count. My fix also removes the resetting of report size and count to 0 because reports can be made up of multiple fields. By removing the reset to 0 it allows the sizes of multiple fields within a report to be added together before then returning once the report id changes. An example of this can be seen the in DualSense 5 controller descriptor.

This logic was based on page 34 of the "Device Class Definition for Human Interface Devices (HID)"
https://www.usb.org/sites/default/files/documents/hid1_11.pdf

It says "One or more fields of data from controls are defined by a Main item and further described by the preceding Global and Local items. Local items only describe the data fields defined by the next Main item. Global items become the default attributes for all subsequent data fields in that descriptor."

It then goes on to show examples of parsing reports inside descriptors that are missing size and count values as well as reports that have multiple fields.
