### PR TITLE
HID device manual connection does not set protocol_mode.

### DIFF
--- a/src/classic/hid_device.c
+++ b/src/classic/hid_device.c
@@ -943,6 +943,7 @@ uint8_t hid_device_connect(bd_addr_t addr, uint16_t * hid_cid){
     hid_device->control_cid   = 0;
     hid_device->interrupt_cid = 0;
     hid_device->con_handle    = HCI_CON_HANDLE_INVALID;
+    hid_device->protocol_mode = HID_PROTOCOL_MODE_REPORT;
 
     // create l2cap control using fixed HID L2CAP PSM
     log_info("Create outgoing HID Control");


### PR DESCRIPTION
When HID device mnually connects to a host by calling hid_device_connect(), the 'protocol_mode' in the device's context struct does not get set.

If the context struct hasn't been zeroed then the protocol_mode will be a garbage value. If it has been zeroed then the protocol_mode will be 'HID_PROTOCOL_MODE_BOOT' (ie the enum value for 0). This does not match the case where a connection is made to the device by the host, which calls hid_device_provide_instance_for_bd_addr() which inits the 'protocol_mode' to 'HID_PROTOCOL_MODE_REPORT'.

This fix will explicitly set protocol_mode upon manual connect to be 'HID_PROTOCOL_MODE_REPORT'.