### PR TITLE
Buffer not always big enough for HID GET_REPORT handling (security issue)

### DIFF
--- a/src/classic/hid_device.c
+++ b/src/classic/hid_device.c
@@ -421,7 +421,7 @@ static void packet_handler(uint8_t packet_type, uint16_t channel, uint8_t * pack
     uint16_t local_cid;
     int pos = 0;
     int report_size;
-    uint8_t report[48];
+    uint8_t report[HCI_ACL_PAYLOAD_SIZE - L2CAP_HEADER_SIZE];
     hid_message_type_t message_type;
 
     switch (packet_type){

--- a/src/classic/hid_device.c
+++ b/src/classic/hid_device.c
@@ -844,8 +844,8 @@ void hid_device_init(bool boot_protocol_mode_supported, uint16_t descriptor_len,
     hci_device_set_report = dummy_set_report;
     hci_device_report_data = dummy_report_data;
 
-    l2cap_register_service(packet_handler, PSM_HID_INTERRUPT, 100, gap_get_security_level());
-    l2cap_register_service(packet_handler, PSM_HID_CONTROL,   100, gap_get_security_level());
+    l2cap_register_service(packet_handler, PSM_HID_INTERRUPT, HID_REPORT_MAX_SIZE, gap_get_security_level());
+    l2cap_register_service(packet_handler, PSM_HID_CONTROL,   HID_REPORT_MAX_SIZE, gap_get_security_level());
 }
 
 void hid_device_deinit(void){


### PR DESCRIPTION
The buffer used to get the GET_REPORT data into from the hci_device_get_report() callback is fixed at 0x30 bytes. This buffer is stored on the stack in packet_handler() inside hci_device.c. This could be too small to contain the full data copied in by the hci_device_get_report() handler. The actual size copied in comes from the HID report descriptor which is custom for each HID device. The hci_device_get_report() callback could potentially perform a buffer overflow on the stack when copying in its data. Note that the code limits the report size returned over BT to 0x30 bytes. This will truncate returned report data that is supposed to be bigger than 0x30 bytes. This truncation occurs after then overflow would have already taken place however.

In addition to producing random crashes this could also result in remote code execution on the device by overwriting the return address on the stack. When combined with the previously submitted issue of incorrect parsing of HID descriptors there is definite scope for "bad things" to occur here.  (Also scope for someone to create a brand name for the bug and do hour long talks about it at security conferences :P)

Only two bytes of the buffer on the stack are used for all cases except the handling of GET_REPORTs.
When handling GET_REPORTs, the buffer needs to be big enough to handle the largest possible GET_REPORT request size. The size of GET_REPORTs is custom per device however, and is defined inside the HID descriptor. The way I deal with this in this fix is to add a define value of 'HID_REPORT_MAX_SIZE' which is by default the size of the max mtu as returned by a call to l2cap_max_mtu(). The user can then define their own custom value for HID_REPORT_MAX_SIZE inside btstack_config.h if they wish to save memory by using a smaller buffer. I also removed the buffer from the stack for the GET_REPORT portion of the code, since a large MTU sized buffer may be too big to fit on the stack on some devices. The buffer is instead statically allocated at compile time.

The MTU for HID control and interrupt channels also needs to be set to the largest possible report size. Potentially two separate size values could be used for max control and max interrupt sizes, but I just used the same max size for simplicity.

The fix as it is works for me, though perhaps you have some other way you would prefer to fix it.

Some info from the Bluetooth HID Profile doc regarding this:
5.2.4 Bluetooth HID device L2CAP Requirements
5.2.4.1 Bluetooth HID device MTU Usage
The implementation of L2CAP on the Bluetooth HID device shall support a receive MTU which is large enough to accommodate the largest report (input, output or feature) defined in the Bluetooth HID device’s report descriptor. This means the MTU on both the interrupt and Control channels shall be large enough to accommodate the largest packet possible, either a SET_REPORT on the Control channel or DATA on the Interrupt channel, including all overheads such as the transaction header and report ID.