### PR TITLE
hci: fix HCI_READ_TRANSMIT_POWER_LEVEL command parameters

### DIFF
--- a/src/hci_cmd.c
+++ b/src/hci_cmd.c
@@ -918,7 +918,7 @@ const hci_cmd_t hci_write_num_broadcast_retransmissions = {
  * @param type 0 = current transmit level, 1 = max transmit level
  */
 const hci_cmd_t hci_read_transmit_power_level = {
-    HCI_OPCODE_HCI_READ_TRANSMIT_POWER_LEVEL, "11"
+    HCI_OPCODE_HCI_READ_TRANSMIT_POWER_LEVEL, "H1"
 };
 
 /**


### PR DESCRIPTION
**Problem**: When sending HCI_READ_TRANSMIT_POWER_LEVEL command controller responds with 'Invalid HCI Command Parameters (0x12)'. Wireshark is also complaining about the command structure

```
Frame 437: 6 bytes on wire (48 bits), 6 bytes captured (48 bits)
Bluetooth
 PacketLogger HCI Command
 Bluetooth HCI Command - Read Tx Power Level
     Command Opcode: Read Tx Power Level (0x0c2d)
     Parameter Total Length: 2
     Connection Handle: 0x0001
 [Malformed Packet: HCI_CMD]
     [Expert Info (Error/Malformed): Malformed Packet (Exception occurred)]
         [Malformed Packet (Exception occurred)]
         [Severity level: Error]
         [Group: Malformed]
```

```
Bluetooth HCI Event - Command Complete
    Event Code: Command Complete (0x0e)
    Parameter Total Length: 6
    Number of Allowed Command Packets: 1
    Command Opcode: Read Tx Power Level (0x0c2d)
    Status: Invalid HCI Command Parameters (0x12)
    Connection Handle: 0x0001
```


According to BLUETOOTH CORE SPECIFICATION Version 5.3 | Vol 4, 7.3.35 Read Transmit Power Level command 's 1st parameter is Connection_Handle which is 2 octets

**How to reproduce** : send HCI_READ_TRANSMIT_POWER_LEVEL command from your code, collect the packet log and analyze.

**Fix**: correct Connection_Hanlde parameter size

**How to verify**: redo the test and check the command status

```
 Frame 422: 7 bytes on wire (56 bits), 7 bytes captured (56 bits)
 Bluetooth
 PacketLogger HCI Command
 Bluetooth HCI Command - Read Tx Power Level
     Command Opcode: Read Tx Power Level (0x0c2d)
     Parameter Total Length: 3
     Connection Handle: 0x0001
     Tx Power Level Type: Current Tx Power Level (0x00)
     [Response in frame: 427]
     [Command-Response Delta: 15,58]
```

```
 Frame 427: 10 bytes on wire (80 bits), 10 bytes captured (80 bits)
 Bluetooth
 PacketLogger HCI Event
 Bluetooth HCI Event - Command Complete
     Event Code: Command Complete (0x0e)
     Parameter Total Length: 7
     Number of Allowed Command Packets: 1
     Command Opcode: Read Tx Power Level (0x0c2d)
     Status: Success (0x00)
     Connection Handle: 0x0001
     Transmit Power Level: 19 dBm
     [Command in frame: 422]
     [Command-Response Delta: 15,58]
```