### PR TITLE
hci_cmd: add hci_write_inquiry_transmit_power_level template

### DIFF
--- a/src/gap.h
+++ b/src/gap.h
@@ -1206,6 +1206,12 @@ void gap_inquiry_set_lap(uint32_t lap);
 void gap_inquiry_set_scan_activity(uint16_t inquiry_scan_interval, uint16_t inquiry_scan_window);
 
 /**
+ * @brief Set Inquiry Transmit Power Level
+ * @param inq_tx_pwr_level range: -70 to 20 dBm
+ */
+void gap_inquiry_set_transmit_power_level(int8_t inq_tx_pwr_level);
+
+/**
  * @brief Remote Name Request
  * @param addr
  * @param page_scan_repetition_mode

--- a/src/hci.c
+++ b/src/hci.c
@@ -1730,6 +1730,12 @@ static void hci_run_gap_tasks_classic(void){
         hci_send_cmd(&hci_write_inquiry_scan_activity, hci_stack->inquiry_scan_interval, hci_stack->inquiry_scan_window);
         return;
     }
+    // send write inquiry transmit power level
+    if ((hci_stack->gap_tasks_classic & GAP_TASK_WRITE_INQUIRY_TX_PWR_LEVEL) != 0) {
+        hci_stack->gap_tasks_classic &= ~GAP_TASK_WRITE_INQUIRY_TX_PWR_LEVEL;
+        hci_send_cmd(&hci_write_inquiry_transmit_power_level, hci_stack->inquiry_tx_power_level);
+        return;
+    }
 }
 #endif
 
@@ -8911,6 +8917,13 @@ void gap_inquiry_set_scan_activity(uint16_t inquiry_scan_interval, uint16_t inqu
     hci_stack->inquiry_scan_interval = inquiry_scan_interval;
     hci_stack->inquiry_scan_window   = inquiry_scan_window;
     hci_stack->gap_tasks_classic |= GAP_TASK_WRITE_INQUIRY_SCAN_ACTIVITY;
+    hci_run();
+}
+
+void gap_inquiry_set_transmit_power_level(int8_t inq_tx_pwr_level)
+{
+    hci_stack->inquiry_tx_power_level = inq_tx_pwr_level;
+    hci_stack->gap_tasks_classic |= GAP_TASK_WRITE_INQUIRY_TX_PWR_LEVEL;
     hci_run();
 }
 

--- a/src/hci.h
+++ b/src/hci.h
@@ -896,6 +896,7 @@ typedef enum hci_init_state{
 #define GAP_TASK_WRITE_PAGE_SCAN_TYPE         0x40
 #define GAP_TASK_WRITE_PAGE_TIMEOUT           0x80
 #define GAP_TASK_WRITE_INQUIRY_SCAN_ACTIVITY 0x100
+#define GAP_TASK_WRITE_INQUIRY_TX_PWR_LEVEL  0x200
 
 enum {
     // Tasks
@@ -1063,6 +1064,7 @@ typedef struct {
     uint32_t            inquiry_lap;      // GAP_IAC_GENERAL_INQUIRY or GAP_IAC_LIMITED_INQUIRY
     uint16_t            inquiry_scan_interval;
     uint16_t            inquiry_scan_window;
+    int8_t              inquiry_tx_power_level;
     
     bool                gap_secure_connections_only_mode;
 #endif

--- a/src/hci_cmd.c
+++ b/src/hci_cmd.c
@@ -1033,6 +1033,20 @@ const hci_cmd_t hci_read_local_oob_data = {
 };
 
 /**
+ */
+const hci_cmd_t hci_read_inquiry_response_transmit_power_level = {
+    HCI_OPCODE_HCI_READ_INQUIRY_RESPONSE_TRANSMIT_POWER_LEVEL, ""
+    // return status, pwr level
+};
+
+/**
+ */
+const hci_cmd_t hci_write_inquiry_transmit_power_level = {
+    HCI_OPCODE_HCI_WRITE_INQUIRY_TRANSMIT_POWER_LEVEL, "1"
+    // return status
+};
+
+/**
  * @param mode (0 = off, 1 = on)
  */
 const hci_cmd_t hci_write_default_erroneous_data_reporting = {

--- a/src/hci_cmd.h
+++ b/src/hci_cmd.h
@@ -177,6 +177,8 @@ typedef enum {
     HCI_OPCODE_HCI_WRITE_EXTENDED_INQUIRY_RESPONSE = HCI_OPCODE (OGF_CONTROLLER_BASEBAND, 0x52),
     HCI_OPCODE_HCI_WRITE_SIMPLE_PAIRING_MODE = HCI_OPCODE (OGF_CONTROLLER_BASEBAND, 0x56),
     HCI_OPCODE_HCI_READ_LOCAL_OOB_DATA = HCI_OPCODE (OGF_CONTROLLER_BASEBAND, 0x57),
+    HCI_OPCODE_HCI_READ_INQUIRY_RESPONSE_TRANSMIT_POWER_LEVEL = HCI_OPCODE (OGF_CONTROLLER_BASEBAND, 0x58),
+    HCI_OPCODE_HCI_WRITE_INQUIRY_TRANSMIT_POWER_LEVEL = HCI_OPCODE (OGF_CONTROLLER_BASEBAND, 0x59),
     HCI_OPCODE_HCI_WRITE_DEFAULT_ERRONEOUS_DATA_REPORTING = HCI_OPCODE (OGF_CONTROLLER_BASEBAND, 0x5B),
     HCI_OPCODE_HCI_SET_EVENT_MASK_2 = HCI_OPCODE (OGF_CONTROLLER_BASEBAND, 0x63),
     HCI_OPCODE_HCI_READ_LE_HOST_SUPPORTED = HCI_OPCODE (OGF_CONTROLLER_BASEBAND, 0x6c),
@@ -390,6 +392,8 @@ extern const hci_cmd_t hci_read_link_supervision_timeout;
 extern const hci_cmd_t hci_read_local_extended_oob_data;
 extern const hci_cmd_t hci_read_local_name;
 extern const hci_cmd_t hci_read_local_oob_data;
+extern const hci_cmd_t hci_read_inquiry_response_transmit_power_level;
+extern const hci_cmd_t hci_write_inquiry_transmit_power_level;
 extern const hci_cmd_t hci_read_local_supported_commands;
 extern const hci_cmd_t hci_read_local_supported_features;
 extern const hci_cmd_t hci_read_local_version_information;


### PR DESCRIPTION
**Problem**: HCI_Write_Inquiry_Transmit_Power_Level  HCI_Read_Inquiry_Response_Transmit_Power_Level command templates are missing

**Fix**: add templates for the commands, add gap_inquiry_set_transmit_power_level to configure inq pwr level from the application code

**How to verify**:  send new commands from your code, ensure they are accepted

```
Frame 588: 4 bytes on wire (32 bits), 4 bytes captured (32 bits)
Bluetooth
PacketLogger HCI Command
Bluetooth HCI Command - Read Inquiry Response Tx Power Level
    Command Opcode: Read Inquiry Response Tx Power Level (0x0c58)
    Parameter Total Length: 0
    [Response in frame: 592]
    [Command-Response Delta: 15,715]
    
    
Frame 592: 8 bytes on wire (64 bits), 8 bytes captured (64 bits)
Bluetooth
PacketLogger HCI Event
Bluetooth HCI Event - Command Complete
    Event Code: Command Complete (0x0e)
    Parameter Total Length: 5
    Number of Allowed Command Packets: 1
    Command Opcode: Read Inquiry Response Tx Power Level (0x0c58)
        0000 11.. .... .... = Opcode Group Field: Host Controller & Baseband Commands (0x03)
        .... ..00 0101 1000 = Opcode Command Field: Read Inquiry Response Tx Power Level (0x058)
    Status: Success (0x00)
    Type: Unknown (0x13)
    [Command in frame: 588]
    [Command-Response Delta: 15,715]
```

```
Frame 605: 5 bytes on wire (40 bits), 5 bytes captured (40 bits)
Bluetooth
PacketLogger HCI Command
Bluetooth HCI Command - Write Inquiry Tx Power Level
    Command Opcode: Write Inquiry Tx Power Level (0x0c59)
    Parameter Total Length: 1
    Power Level (dBm): 20
    [Response in frame: 609]
    [Command-Response Delta: 15,723]


Frame 609: 7 bytes on wire (56 bits), 7 bytes captured (56 bits)
Bluetooth
PacketLogger HCI Event
Bluetooth HCI Event - Command Complete
    Event Code: Command Complete (0x0e)
    Parameter Total Length: 4
    Number of Allowed Command Packets: 1
    Command Opcode: Write Inquiry Tx Power Level (0x0c59)
        0000 11.. .... .... = Opcode Group Field: Host Controller & Baseband Commands (0x03)
        .... ..00 0101 1001 = Opcode Command Field: Write Inquiry Tx Power Level (0x059)
    Status: Success (0x00)
    [Command in frame: 605]
    [Command-Response Delta: 15,723]
```

