### PR TITLE
(small fix) Use memcpy instead of copying bytes manually

### DIFF
--- a/src/classic/hfp_hf.c
+++ b/src/classic/hfp_hf.c
@@ -1556,10 +1556,7 @@ void hfp_hf_init_codecs(int codecs_nr, const uint8_t * codecs){
     btstack_assert(codecs_nr <= HFP_MAX_NUM_CODECS);
 
     hfp_hf_codecs_nr = codecs_nr;
-    int i;
-    for (i=0; i<codecs_nr; i++){
-        hfp_hf_codecs[i] = codecs[i];
-    }
+    memcpy(hfp_hf_codecs, codecs, codecs_nr);
 }
 
 void hfp_hf_init_supported_features(uint32_t supported_features){


### PR DESCRIPTION
This is cleaner and more efficient, but more importantly it fixes this annoying GCC warning:
```
hfp_hf.c:1561:26: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
 1561 |         hfp_hf_codecs[i] = codecs[i];
      |         ~~~~~~~~~~~~~~~~~^~~~~~~~~~~
```