### PR TITLE
compile_gatt.py: add clang-format off to header

### DIFF
--- a/tool/compile_gatt.py
+++ b/tool/compile_gatt.py
@@ -38,6 +38,7 @@ except ImportError:
         print("[!] Please install PyCryptodome, e.g. 'pip3 install pycryptodomex' or 'pip3 install pycryptodome'\n")
 
 header = '''
+// clang-format off
 // {0} generated from {1} for BTstack
 // it needs to be regenerated when the .gatt file is updated. 
 


### PR DESCRIPTION
Add clang-format off to header.
Useful when the auto-generated headers are checked-in a repo with clang-format enabled.