### PR TITLE
dis: fix the assert problem caused by function re-entry

### DIFF
--- a/src/ble/gatt-service/device_information_service_client.c
+++ b/src/ble/gatt-service/device_information_service_client.c
@@ -455,6 +455,10 @@ uint8_t device_information_service_client_query(hci_con_handle_t con_handle, bts
     } 
 
     client = device_information_service_client_get_client();
+
+    if (client->con_handle != HCI_CON_HANDLE_INVALID) {
+        return ERROR_CODE_COMMAND_DISALLOWED;
+    }
     
     client->con_handle = con_handle;
     client->client_handler = packet_handler; 


### PR DESCRIPTION
current DIS will cause an assert in GATT_EVENT_CHARACTERISTIC_VALUE_QUERY_RESULT when:

1. a DIS is doing;
2. user call func device_information_service_client_query again;

By making a parameter judgment in device_information_service_client_query, the problem will be fixed.