### PR TITLE
Fix gcc compile warnings

### DIFF
--- a/src/btstack_hid_parser.c
+++ b/src/btstack_hid_parser.c
@@ -147,12 +147,12 @@ static void hid_pretty_print_item(btstack_hid_parser_t * parser, hid_descriptor_
 }
 
 // parse descriptor item and read up to 32-bit bit value
-void btstack_hid_parse_descriptor_item(hid_descriptor_item_t * item, const uint8_t * hid_descriptor, uint16_t hid_descriptor_len){
+bool btstack_hid_parse_descriptor_item(hid_descriptor_item_t * item, const uint8_t * hid_descriptor, uint16_t hid_descriptor_len){
 
     const int hid_item_sizes[] = { 0, 1, 2, 4 };
 
     // parse item header
-    if (hid_descriptor_len < 1u) return;
+    if (hid_descriptor_len < 1u) return false;
     uint16_t pos = 0;
     uint8_t item_header = hid_descriptor[pos++];
     item->data_size = hid_item_sizes[item_header & 0x03u];
@@ -160,7 +160,7 @@ void btstack_hid_parse_descriptor_item(hid_descriptor_item_t * item, const uint8
     item->item_tag  = (item_header & 0xf0u) >> 4u;
     // long item
     if ((item->data_size == 2u) && (item->item_tag == 0x0fu) && (item->item_type == 3u)){
-        if (hid_descriptor_len < 3u) return;
+        if (hid_descriptor_len < 3u) return false;
         item->data_size = hid_descriptor[pos++];
         item->item_tag  = hid_descriptor[pos++];
     }
@@ -168,8 +168,8 @@ void btstack_hid_parse_descriptor_item(hid_descriptor_item_t * item, const uint8
     item->item_value = 0;
 
     // read item value
-    if (hid_descriptor_len < item->item_size) return;
-    if (item->data_size > 4u) return;
+    if (hid_descriptor_len < item->item_size) return false;
+    if (item->data_size > 4u) return false;
     int i;
     int sgnd = (item->item_type == Global) && (item->item_tag > 0u) && (item->item_tag < 5u);
     int32_t value = 0;
@@ -184,6 +184,7 @@ void btstack_hid_parse_descriptor_item(hid_descriptor_item_t * item, const uint8
         }
     }
     item->item_value = value;
+    return true;
 }
 
 static void btstack_hid_handle_global_item(btstack_hid_parser_t * parser, hid_descriptor_item_t * item){
@@ -232,7 +233,8 @@ static void hid_find_next_usage(btstack_hid_parser_t * parser){
     while ((parser->available_usages == 0u) && (parser->usage_pos < parser->descriptor_pos)){
         hid_descriptor_item_t usage_item;
         // parser->usage_pos < parser->descriptor_pos < parser->descriptor_len
-        btstack_hid_parse_descriptor_item(&usage_item, &parser->descriptor[parser->usage_pos], parser->descriptor_len - parser->usage_pos);
+        if (!btstack_hid_parse_descriptor_item(&usage_item, &parser->descriptor[parser->usage_pos], parser->descriptor_len - parser->usage_pos))
+        	break;
         if ((usage_item.item_type == Global) && (usage_item.item_tag == UsagePage)){
             parser->usage_page = usage_item.item_value;
         }
@@ -336,7 +338,8 @@ static void btstack_hid_parser_find_next_usage(btstack_hid_parser_t * parser){
             parser->state = BTSTACK_HID_PARSER_COMPLETE;
             break;
         }
-        btstack_hid_parse_descriptor_item(&parser->descriptor_item, &parser->descriptor[parser->descriptor_pos], parser->descriptor_len - parser->descriptor_pos);
+        if (!btstack_hid_parse_descriptor_item(&parser->descriptor_item, &parser->descriptor[parser->descriptor_pos], parser->descriptor_len - parser->descriptor_pos))
+        	break;
         hid_process_item(parser, &parser->descriptor_item);
         if (parser->required_usages){
             hid_find_next_usage(parser);
@@ -442,7 +445,8 @@ int btstack_hid_get_report_size_for_id(int report_id, hid_report_type_t report_t
     while (hid_descriptor_len){
         int valid_report_type = 0;
         hid_descriptor_item_t item;
-        btstack_hid_parse_descriptor_item(&item, hid_descriptor, hid_descriptor_len);
+        if (!btstack_hid_parse_descriptor_item(&item, hid_descriptor, hid_descriptor_len))
+        	break;
         switch (item.item_type){
             case Global:
                 switch ((GlobalItemTag)item.item_tag){
@@ -494,7 +498,8 @@ hid_report_id_status_t btstack_hid_id_valid(int report_id, uint16_t hid_descript
     int current_report_id = 0;
     while (hid_descriptor_len){
         hid_descriptor_item_t item;
-        btstack_hid_parse_descriptor_item(&item, hid_descriptor, hid_descriptor_len);
+        if (!btstack_hid_parse_descriptor_item(&item, hid_descriptor, hid_descriptor_len))
+        	break;
         switch (item.item_type){
             case Global:
                 switch ((GlobalItemTag)item.item_tag){
@@ -519,7 +524,8 @@ hid_report_id_status_t btstack_hid_id_valid(int report_id, uint16_t hid_descript
 int btstack_hid_report_id_declared(uint16_t hid_descriptor_len, const uint8_t * hid_descriptor){
     while (hid_descriptor_len){
         hid_descriptor_item_t item;
-        btstack_hid_parse_descriptor_item(&item, hid_descriptor, hid_descriptor_len);
+        if (!btstack_hid_parse_descriptor_item(&item, hid_descriptor, hid_descriptor_len))
+        	break;
         switch (item.item_type){
             case Global:
                 switch ((GlobalItemTag)item.item_tag){

--- a/src/btstack_hid_parser.h
+++ b/src/btstack_hid_parser.h
@@ -185,7 +185,7 @@ void btstack_hid_parser_get_field(btstack_hid_parser_t * parser, uint16_t * usag
  * @param hid_descriptor
  * @param hid_descriptor_len
  */
-void btstack_hid_parse_descriptor_item(hid_descriptor_item_t * item, const uint8_t * hid_descriptor, uint16_t hid_descriptor_len);
+bool btstack_hid_parse_descriptor_item(hid_descriptor_item_t * item, const uint8_t * hid_descriptor, uint16_t hid_descriptor_len);
 
 /**
  * @brief Parses descriptor and returns report size for given report ID and report type

--- a/src/classic/hfp_ag.c
+++ b/src/classic/hfp_ag.c
@@ -2630,7 +2630,7 @@ void hfp_ag_init_codecs(uint8_t codecs_nr, const uint8_t * codecs){
 
     hfp_ag_codecs_nr = codecs_nr;
     uint8_t i;
-    for (i=0; i < codecs_nr; i++){
+    for (i=0; i < codecs_nr && i < HFP_MAX_NUM_CODECS; i++){
         hfp_ag_codecs[i] = codecs[i];
     }
 }

--- a/src/classic/hfp_hf.c
+++ b/src/classic/hfp_hf.c
@@ -1553,7 +1553,7 @@ void hfp_hf_init_codecs(uint8_t codecs_nr, const uint8_t * codecs){
 
     hfp_hf_codecs_nr = codecs_nr;
     uint8_t i;
-    for (i=0; i<codecs_nr; i++){
+    for (i=0; i<codecs_nr && i < HFP_MAX_NUM_CODECS; i++){
         hfp_hf_codecs[i] = codecs[i];
     }
 }
@@ -1567,7 +1567,7 @@ void hfp_hf_init_hf_indicators(int indicators_nr, const uint16_t * indicators){
 
     hfp_hf_indicators_nr = indicators_nr;
     int i;
-    for (i = 0; i < hfp_hf_indicators_nr ; i++){
+    for (i = 0; i < hfp_hf_indicators_nr && i < HFP_MAX_NUM_INDICATORS; i++){
         hfp_hf_indicators[i] = (uint8_t) indicators[i];
     }
 


### PR DESCRIPTION
Fix gcc compile warnings (uninitialized variable usage. out-of bound  access) with use -Ofast -flto