### PR TITLE
test/mesh: fix `sbc_encoder.h not found` by including ./3rd-party/bludroid/*

### DIFF
--- a/test/mesh/CMakeLists.txt
+++ b/test/mesh/CMakeLists.txt
@@ -20,6 +20,8 @@ include_directories(${LIBUSB_INCLUDE_DIRS})
 link_directories(${LIBUSB_LIBRARY_DIRS})
 link_libraries(${LIBUSB_LIBRARIES})
 
+include_directories(../../3rd-party/bluedroid/decoder/include)
+include_directories(../../3rd-party/bluedroid/encoder/include)
 include_directories(../../3rd-party/micro-ecc)
 include_directories(../../3rd-party/rijndael)
 include_directories(../../3rd-party/tinydir)


### PR DESCRIPTION
# The Problem

```bash
[  0%] Building C object CMakeFiles/btstack.dir/pico/pico-sdk/lib/btstack/3rd-party/micro-ecc/uECC.c.o
[  1%] Building C object CMakeFiles/btstack.dir/pico/pico-sdk/lib/btstack/example/sco_demo_util.c.o
In file included from /pico/pico-sdk/lib/btstack/example/sco_demo_util.c:53:
/pico/pico-sdk/lib/btstack/test/mesh/../../src/classic/btstack_sbc_bluedroid.h:45:10: fatal error: 'sbc_encoder.h' file not found
#include "sbc_encoder.h"
         ^~~~~~~~~~~~~~~
1 error generated.
make[2]: *** [CMakeFiles/btstack.dir/pico/pico-sdk/lib/btstack/example/sco_demo_util.c.o] Error 1
make[1]: *** [CMakeFiles/btstack.dir/all] Error 2
make: *** [all] Error 2
```

# The Solution

Include `./3rd-party/bludroid/*` (see diff)