### PR TITLE
Fix/jkb/compilation gcc debian

### DIFF
--- a/chipset/cc256x/cc256x.cmake
+++ b/chipset/cc256x/cc256x.cmake
@@ -9,6 +9,7 @@
 set(BLUEKITCHEN_URL https://bluekitchen-gmbh.com/files/ti/service-packs)
 set(CONVERSION_SCRIPT ${BTSTACK_ROOT}/chipset/cc256x/convert_bts_init_scripts.py)
 
+find_package (Python REQUIRED COMPONENTS Interpreter)
 #
 # Service Pack / Init Script / .bts Conversion function
 #
@@ -33,7 +34,7 @@ function(cc256x_init_script output_file archive main_script optional_script)
             add_custom_command(
                     OUTPUT ${output_file}
                     DEPENDS ${main_script} ${optional_script}
-                    COMMAND python
+                    COMMAND ${Python_EXECUTABLE}
                     ARGS ${CONVERSION_SCRIPT} ${main_script} ${optional_script} ${output_file}
             )
 

--- a/port/raspi/main.c
+++ b/port/raspi/main.c
@@ -329,6 +329,7 @@ int main(int argc, const char * argv[]){
     int bt_reg_en_pin = -1;
     bool power_cycle = true;
     switch (raspi_get_bluetooth_uart_type()){
+		default:
         case UART_INVALID:
             fprintf(stderr, "can't verify HW uart, %s\n", strerror( errno ) );
             return -1;

--- a/port/raspi/main.c
+++ b/port/raspi/main.c
@@ -329,7 +329,6 @@ int main(int argc, const char * argv[]){
     int bt_reg_en_pin = -1;
     bool power_cycle = true;
     switch (raspi_get_bluetooth_uart_type()){
-		default:
         case UART_INVALID:
             fprintf(stderr, "can't verify HW uart, %s\n", strerror( errno ) );
             return -1;
@@ -370,6 +369,8 @@ int main(int argc, const char * argv[]){
                 printf("Please add ENABLE_CONTROLLER_WARM_BOOT to btstack_config.h to enable startup without RESET\n");
             }
 #endif
+            break;
+        default:
             break;
     }
     printf("%s, %u, BT_REG_EN at GPIO %u, %s\n", transport_config.flowcontrol ? "H4":"H5", transport_config.baudrate_main, bt_reg_en_pin, power_cycle ? "Reset Controller" : "Warm Boot");

--- a/src/hci_transport_h5.c
+++ b/src/hci_transport_h5.c
@@ -671,7 +671,7 @@ static void hci_transport_h5_process_frame(uint16_t frame_size){
                     hci_transport_inactivity_timer_set();
                     break;
                  default:
-					 break;
+                    break;
             }
 
             break;

--- a/src/hci_transport_h5.c
+++ b/src/hci_transport_h5.c
@@ -670,6 +670,8 @@ static void hci_transport_h5_process_frame(uint16_t frame_size){
                     // reset inactvitiy timer
                     hci_transport_inactivity_timer_set();
                     break;
+                 default:
+					 break;
             }
 
             break;


### PR DESCRIPTION
- Resolved python executable was not respected in cc256x.cmake, instead "python" was used. On systems with python executable being called python3, etc., this is not working.
- default cases were missing and were identified as a problem by gcc compiler with -Werror. Maybe it is not a good idea to just break on default case (original behavior when no case was hit), maybe some error state could be more suitable, but I don't know the stack well enough to say.