### PR TITLE
hci: fix hci connection release on cancel

### DIFF
--- a/src/hci.c
+++ b/src/hci.c
@@ -3403,6 +3403,8 @@ static void hci_handle_le_connection_complete_event(const uint8_t * hci_event){
 
 		// free connection if cancelled by user (request == IDLE)
         bool cancelled_by_user = hci_stack->le_connecting_request == LE_CONNECTING_IDLE;
+        // get outgoing connection conn to free slot if cancelled by user
+        conn = gap_get_outgoing_le_connection();
 		if ((conn != NULL) && cancelled_by_user){
 			// remove entry
 			btstack_linked_list_remove(&hci_stack->connections, (btstack_linked_item_t *) conn);


### PR DESCRIPTION
If the LE connection is aborted by the user, the HCI connection is not released after receiving the `LE connection complete` event. This is caused by the `conn` pointer being `null` because the connection complete event does not contain an address in this case.
It used to work because the current outgoing connection was always assigned to the `conn` pointer. This has changed in commit [9fd274a](https://github.com/bluekitchen/btstack/commit/9fd274a1e93226c6b897affd93ad5315018d96e8).