### PR TITLE
hids_device: propagate result of request_can_send_now_event

### DIFF
--- a/src/ble/gatt-service/hids_device.c
+++ b/src/ble/gatt-service/hids_device.c
@@ -555,16 +555,16 @@ void hids_device_register_get_report_callback(void (*callback)(hci_con_handle_t 
  * Generates an HIDS_SUBEVENT_CAN_SEND_NOW subevent
  * @param hid_cid
  */
-void hids_device_request_can_send_now_event(hci_con_handle_t con_handle){
+uint8_t hids_device_request_can_send_now_event(hci_con_handle_t con_handle){
     hids_device_t * instance = hids_device_get_instance_for_con_handle(con_handle);
     if (!instance){
         log_error("no instance for handle 0x%02x", con_handle);
-        return;
+        return ERROR_CODE_UNKNOWN_CONNECTION_IDENTIFIER;
     }
 
     instance->can_send_now_callback.callback = &hids_device_can_send_now;
     instance->can_send_now_callback.context  = (void*) (uintptr_t) con_handle;
-    att_server_register_can_send_now_callback(&instance->can_send_now_callback, con_handle);
+    return att_server_register_can_send_now_callback(&instance->can_send_now_callback, con_handle);
 }
 
 uint8_t hids_device_send_input_report_for_id(hci_con_handle_t con_handle, uint16_t report_id, const uint8_t * report, uint16_t report_len){

--- a/src/ble/gatt-service/hids_device.h
+++ b/src/ble/gatt-service/hids_device.h
@@ -96,8 +96,9 @@ void hids_device_register_get_report_callback(void (*callback)(hci_con_handle_t 
  * @brief Request can send now event to send HID Report
  * Generates an HIDS_SUBEVENT_CAN_SEND_NOW subevent
  * @param hid_cid
+ * @return ERROR_CODE_SUCCESS if ok, ERROR_CODE_UNKNOWN_CONNECTION_IDENTIFIER if handle unknown, and ERROR_CODE_COMMAND_DISALLOWED if callback already registered
  */
-void hids_device_request_can_send_now_event(hci_con_handle_t con_handle);
+uint8_t hids_device_request_can_send_now_event(hci_con_handle_t con_handle);
 
 /**
  * @brief Send HID Input Report for Report ID


### PR DESCRIPTION
While investigating a stuck HID report request in my application, I've noticed that internal error conditions of `hids_device_request_can_send_now_event` are not propagated back to the caller.

This PR adds a return status code, so the caller can react accordingly and doesn't expect the `HIDS_SUBEVENT_CAN_SEND_NOW` event to happen.