### PR TITLE
att_db_util: Add API to specify next attribute handle.

### DIFF
--- a/src/ble/att_db_util.c
+++ b/src/ble/att_db_util.c
@@ -89,6 +89,11 @@ void att_db_util_init(void){
 	att_db_util_set_end_tag();
 }
 
+void att_db_util_set_next_handle(uint16_t handle){
+   btstack_assert(handle >= att_db_next_handle); // do not reuse assigned handles
+   att_db_next_handle = handle;
+}
+
 static bool att_db_util_hash_include_with_value(uint16_t uuid16){
     /* «Primary Service», «Secondary Service», «Included Service», «Characteristic», or «Characteristic Extended Properties» */
     switch (uuid16){

--- a/src/ble/att_db_util.h
+++ b/src/ble/att_db_util.h
@@ -62,6 +62,13 @@ extern "C" {
 void att_db_util_init(void);
 
 /**
+ * @brief Set handle value for next table entry
+ * @param handle
+ * @note new handle must be >= previous to avoid reusing assigned handles
+ */
+void att_db_util_set_next_handle(uint16_t handle);
+
+/**
  * @brief Add primary service for 16-bit UUID
  * @param uuid16
  * @return attribute handle for the new service definition


### PR DESCRIPTION
Our BTLE usage requires our peripheral to enable / disable certain GATT services at runtime and inform the host device via sending a Notify to the Service Changed characteristic. We are using `att_db_util` to re-construct the ATT table as needed.

Our ATT table layout is:
```{GAP attributes, HID attributes, Custom service attributes}```
Depending on what is enabled or disabled, this layout can change to
`{GAP attributes, Custom service attributes}`, or
`{GAP attributes, HID attributes}`.

Currently, `att_db_util` appends all services with an incrementing sequence of handles. This means when we change our layout, the handles associated with the HID and Custom services' attributes change. We have found that not all BTLE hosts respect the Service Changed feature in the way we would like. Therefore, we would like to ensure our services always start at a certain handle value.

I have added a extra method to the API to allow the `att_db_next_handle` to be moved ahead. This method enables us to ensure specific services always have the same handle:
```
att_db_util_set_next_handle(0x100);
uint16_t first_hid_handle = att_db_util_add_service_uuid16(ORG_BLUETOOTH_SERVICE_HUMAN_INTERFACE_DEVICE);
assert(first_hid_handle == 0x100);
// add rest of HID attributes

att_db_util_set_next_handle(0x200);
uint16_t first_custom_handle = att_db_util_add_service_uuid128(CUSTOM_SERVICE_UUID128);
assert(first_custom_handle == 0x200);
// add rest of custom service attributes
``` 

Additionally, this method allows users to "reserve" handle space for future expansion. 
e.g. I could start Custom service 1 at handle 0x100 and Custom service 2 at 0x200. The handle range between 0x100-0x200 can be reserved for future attributes for Custom service 1, without changing the handle values for Custom service 2.
