### PR TITLE
Adding __pycache__ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ build-coverage
 .vs
 .vscode
 ninja
+__pycache__


### PR DESCRIPTION
When this submodule was used within 'bluepad32' (git@github.com:ricardoquesada/bluepad32.git), "port/esp32/__pycache__/" was flagged as a modification.
Adding '__pycache__' to the .gitignore of this submodule prevents it from being flagged as a change.