### PR TITLE
Add gatt_client_discover_primary_services_by_uuid128_with_context, wh…

### DIFF
--- a/src/ble/gatt_client.c
+++ b/src/ble/gatt_client.c
@@ -2600,6 +2600,11 @@ uint8_t gatt_client_discover_primary_services_by_uuid16(btstack_packet_handler_t
 }
 
 uint8_t gatt_client_discover_primary_services_by_uuid128(btstack_packet_handler_t callback, hci_con_handle_t con_handle, const uint8_t * uuid128){
+    return gatt_client_discover_primary_services_by_uuid128_with_context(callback, con_handle, uuid128, 0, 0);
+}
+
+uint8_t gatt_client_discover_primary_services_by_uuid128_with_context(btstack_packet_handler_t callback, hci_con_handle_t con_handle,
+                                                                      const uint8_t * uuid128, uint16_t service_id, uint16_t connection_id){
     gatt_client_t * gatt_client;
     uint8_t status = gatt_client_provide_context_for_request(con_handle, &gatt_client);
     if (status != ERROR_CODE_SUCCESS){
@@ -2607,6 +2612,8 @@ uint8_t gatt_client_discover_primary_services_by_uuid128(btstack_packet_handler_
     }
 
     gatt_client->callback = callback;
+    gatt_client->service_id = service_id;
+    gatt_client->connection_id = connection_id;
     gatt_client->start_group_handle = 0x0001;
     gatt_client->end_group_handle   = 0xffff;
     gatt_client->uuid16 = 0;

--- a/src/ble/gatt_client.h
+++ b/src/ble/gatt_client.h
@@ -485,6 +485,22 @@ uint8_t gatt_client_discover_primary_services_by_uuid16_with_context(btstack_pac
  */
 uint8_t gatt_client_discover_primary_services_by_uuid128(btstack_packet_handler_t callback, hci_con_handle_t con_handle, const uint8_t * uuid128);
 
+/**
+ * @brief Discovers a specific primary service given its UUID. This service may exist multiple times. 
+ * For each found service a GATT_EVENT_SERVICE_QUERY_RESULT event will be emitted.
+ * The GATT_EVENT_QUERY_COMPLETE event marks the end of discovery. 
+ * @param callback   
+ * @param con_handle
+ * @param uuid128
+ * @param service_id    - context provided to callback in events
+ * @param connection_id - context provided to callback in events
+ * @return status BTSTACK_MEMORY_ALLOC_FAILED, if no GATT client for con_handle is found 
+ *                GATT_CLIENT_IN_WRONG_STATE , if GATT client is not ready
+ *                ERROR_CODE_SUCCESS         , if query is successfully registered  
+ */
+uint8_t gatt_client_discover_primary_services_by_uuid128_with_context(btstack_packet_handler_t callback, hci_con_handle_t con_handle,
+                                                                      const uint8_t * uuid128, uint16_t service_id, uint16_t connection_id);
+
 /** 
  * @brief Finds included services within the specified service. 
  * For each found included service a GATT_EVENT_INCLUDED_SERVICE_QUERY_RESULT event will be emitted. 


### PR DESCRIPTION
Add gatt_client_discover_primary_services_by_uuid128_with_context, which allows providing a context for 128-bit UUID service discovery, like the existing 16-bit version.