### PR TITLE
avrcp_controller: implement player application setting changed notification

### DIFF
--- a/src/btstack_defines.h
+++ b/src/btstack_defines.h
@@ -3325,8 +3325,14 @@ typedef SSIZE_T ssize_t;
  */
 #define AVRCP_SUBEVENT_NOTIFICATION_EVENT_SYSTEM_STATUS_CHANGED                     0x07u
 
-
-// Recquires 1 byte for num_attributes, followed by num_attributes tuples [attribute_id(1), value_id(1)], see avrcp_player_application_setting_attribute_id_t
+/**
+ * @format 12111
+ * @param subevent_code
+ * @param avrcp_cid
+ * @param command_type
+ * @param attribute_id  see avrcp_player_application_setting_attribute_id_t
+ * @param value_id  see avrcp_shuffle_mode_t, avrcp_repeat_mode_t
+ */
 #define AVRCP_SUBEVENT_NOTIFICATION_EVENT_PLAYER_APPLICATION_SETTING_CHANGED        0x08u
 
 /**

--- a/src/btstack_event.h
+++ b/src/btstack_event.h
@@ -11121,6 +11121,43 @@ static inline uint32_t avrcp_subevent_notification_event_playback_pos_changed_ge
 }
 
 /**
+ * @brief Get field avrcp_cid from event AVRCP_SUBEVENT_NOTIFICATION_EVENT_PLAYER_APPLICATION_SETTING_CHANGED
+ * @param event packet
+ * @return avrcp_cid
+ * @note: btstack_type 2
+ */
+static inline uint16_t avrcp_subevent_notification_event_player_application_setting_changed_get_avrcp_cid(const uint8_t * event){
+    return little_endian_read_16(event, 3);
+}
+/**
+ * @brief Get field command_type from event AVRCP_SUBEVENT_NOTIFICATION_EVENT_PLAYER_APPLICATION_SETTING_CHANGED
+ * @param event packet
+ * @return command_type
+ * @note: btstack_type 1
+ */
+static inline uint8_t avrcp_subevent_notification_event_player_application_setting_changed_get_command_type(const uint8_t * event){
+    return event[5];
+}
+/**
+ * @brief Get field attribute_id from event AVRCP_SUBEVENT_NOTIFICATION_EVENT_PLAYER_APPLICATION_SETTING_CHANGED
+ * @param event packet
+ * @return attribute_id
+ * @note: btstack_type 1
+ */
+static inline uint8_t avrcp_subevent_notification_event_player_application_setting_changed_get_attribute_id(const uint8_t * event){
+    return event[6];
+}
+/**
+ * @brief Get field value_id from event AVRCP_SUBEVENT_NOTIFICATION_EVENT_PLAYER_APPLICATION_SETTING_CHANGED
+ * @param event packet
+ * @return value_id
+ * @note: btstack_type 1
+ */
+static inline uint8_t avrcp_subevent_notification_event_player_application_setting_changed_get_value_id(const uint8_t * event){
+    return event[7];
+}
+
+/**
  * @brief Get field avrcp_cid from event AVRCP_SUBEVENT_NOTIFICATION_EVENT_BATT_STATUS_CHANGED
  * @param event packet
  * @return avrcp_cid

--- a/src/classic/avrcp_controller.c
+++ b/src/classic/avrcp_controller.c
@@ -346,7 +346,27 @@ static void avrcp_controller_emit_notification_for_event_id(uint16_t avrcp_cid, 
             break;
         }
 
-        case AVRCP_NOTIFICATION_EVENT_PLAYER_APPLICATION_SETTING_CHANGED:
+        case AVRCP_NOTIFICATION_EVENT_PLAYER_APPLICATION_SETTING_CHANGED:{
+            if (size < 1) break;
+            uint16_t pos = 0;
+            uint16_t num_attributes = payload[pos++];
+            if (size < 2 * num_attributes + 1) break;
+            uint16_t offset = 0;
+            uint8_t event[8];
+            event[offset++] = HCI_EVENT_AVRCP_META;
+            event[offset++] = sizeof(event) - 2;
+            event[offset++] = AVRCP_SUBEVENT_NOTIFICATION_EVENT_PLAYER_APPLICATION_SETTING_CHANGED;
+            little_endian_store_16(event, offset, avrcp_cid);
+            offset += 2;
+            event[offset++] = ctype;
+            for (int i = 0; i < num_attributes; i++) {
+                event[offset] = payload[pos++];
+                event[offset + 1] = payload[pos++];
+                (*avrcp_controller_context.avrcp_callback)(HCI_EVENT_PACKET, 0, event, offset + 1);
+            }
+            break;
+        }
+
         default:
             log_info("avrcp: not implemented");
             break;


### PR DESCRIPTION
This PR implements the `AVRCP_NOTIFICATION_EVENT_PLAYER_APPLICATION_SETTING_CHANGED` for AVRCP controller, i.e. passing the notification to the application's packet handler.

To keep a consistent format and length of the packet, a separate event is sent for each attribute present in the received notification.

This was tested on:
- iPhone 7 - works fine,
- Nokia N8-00 - works fine,
- Galaxy A31s (Android 12) - notification not supported,
- Xiaomi Redmi Note 4 (Android 8) - notification not supported.