### PR TITLE
avrcp_browsing_controller: fix missing UID counter in change path command

### DIFF
--- a/src/classic/avrcp_browsing_controller.c
+++ b/src/classic/avrcp_browsing_controller.c
@@ -162,6 +162,7 @@ static int avrcp_browsing_controller_send_change_path_cmd(uint16_t cid, avrcp_br
 
     big_endian_store_16(command, pos, 11);
     pos += 2;
+    big_endian_store_16(command, pos, connection->uid_counter);
     pos += 2;
     command[pos++] = connection->direction;
     (void)memcpy(command + pos, connection->item_uid, 8);


### PR DESCRIPTION
This PR fixes a missing `uid_counter` when sending AVRCP ChangePath command.

Previously, the field was uninitialized, leading to a random value being sent over to the AVRCP TG device. While Android devices didn't seem to care about it, an iPhone was responding with error 0x05 - `UID Changed – The UIDs on the device have changed`. This made browsing impossible.