### PR TITLE
avdtp: fill avdtp_cid in avdtp_connect if SLC not yet complete

### DIFF
--- a/src/classic/avdtp.c
+++ b/src/classic/avdtp.c
@@ -348,6 +348,9 @@ uint8_t avdtp_connect(bd_addr_t remote, avdtp_role_t role, uint16_t * avdtp_cid)
         // allow to call avdtp_connect after signaling connection was triggered remotely
         // @note this also allows to call avdtp_connect again before SLC is complete
         if (connection->state < AVDTP_SIGNALING_CONNECTION_OPENED){
+            if (avdtp_cid != NULL) {
+                *avdtp_cid = connection->avdtp_cid;
+            }
             return ERROR_CODE_SUCCESS;
         } else {
             return ERROR_CODE_COMMAND_DISALLOWED;


### PR DESCRIPTION
This PR fills in the `avdtp_cid` in `avdtp_connect()` when the connection hasn't been opened yet.

- When calling `a2dp_sink_establish_stream()` for the first time, `avdtp_connect()` allocates a new AVDTP connection and assigns a CID to it.
- When calling it again (to retry connection, perhaps) the connection state is not yet `AVDTP_SIGNALING_CONNECTION_OPENED`. The `avdtp_connect()` method returns SUCCESS, but doesn't fill in the `avdtp_cid` pointer.
- This causes `a2dp_sink_establish_stream()` to not find the connection object and [fail an assertion](https://github.com/bluekitchen/btstack/blob/develop/src/classic/a2dp_sink.c#L134).

This PR aims to fix this problem.