### PR TITLE
avrcp_controller: implement addressed player changed notification

### DIFF
--- a/src/btstack_defines.h
+++ b/src/btstack_defines.h
@@ -3356,7 +3356,15 @@ typedef SSIZE_T ssize_t;
  */
 #define AVRCP_SUBEVENT_NOTIFICATION_AVAILABLE_PLAYERS_CHANGED                       0x0Au
 
-// AVRCP_SUBEVENT_NOTIFICATION_EVENT_ADDRESSED_PLAYER_CHANGED = 0x0bu,           -- The Addressed Player has been changed, see 6.9.2.
+/**
+ * @format 12122
+ * @param subevent_code
+ * @param avrcp_cid
+ * @param command_type
+ * @param player_id
+ * @param uid_counter
+ */
+#define AVRCP_SUBEVENT_NOTIFICATION_ADDRESSED_PLAYER_CHANGED                        0x0Bu
 
 /**
  * @format 1212

--- a/src/btstack_event.h
+++ b/src/btstack_event.h
@@ -11252,6 +11252,43 @@ static inline uint8_t avrcp_subevent_notification_available_players_changed_get_
 }
 
 /**
+ * @brief Get field avrcp_cid from event AVRCP_SUBEVENT_NOTIFICATION_ADDRESSED_PLAYER_CHANGED
+ * @param event packet
+ * @return avrcp_cid
+ * @note: btstack_type 2
+ */
+static inline uint16_t avrcp_subevent_notification_addressed_player_changed_get_avrcp_cid(const uint8_t * event){
+    return little_endian_read_16(event, 3);
+}
+/**
+ * @brief Get field command_type from event AVRCP_SUBEVENT_NOTIFICATION_ADDRESSED_PLAYER_CHANGED
+ * @param event packet
+ * @return command_type
+ * @note: btstack_type 1
+ */
+static inline uint8_t avrcp_subevent_notification_addressed_player_changed_get_command_type(const uint8_t * event){
+    return event[5];
+}
+/**
+ * @brief Get field player_id from event AVRCP_SUBEVENT_NOTIFICATION_ADDRESSED_PLAYER_CHANGED
+ * @param event packet
+ * @return player_id
+ * @note: btstack_type 2
+ */
+static inline uint16_t avrcp_subevent_notification_addressed_player_changed_get_player_id(const uint8_t * event){
+    return little_endian_read_16(event, 6);
+}
+/**
+ * @brief Get field uid_counter from event AVRCP_SUBEVENT_NOTIFICATION_ADDRESSED_PLAYER_CHANGED
+ * @param event packet
+ * @return uid_counter
+ * @note: btstack_type 2
+ */
+static inline uint16_t avrcp_subevent_notification_addressed_player_changed_get_uid_counter(const uint8_t * event){
+    return little_endian_read_16(event, 8);
+}
+
+/**
  * @brief Get field avrcp_cid from event AVRCP_SUBEVENT_NOTIFICATION_EVENT_UIDS_CHANGED
  * @param event packet
  * @return avrcp_cid

--- a/src/classic/avrcp_controller.c
+++ b/src/classic/avrcp_controller.c
@@ -261,6 +261,24 @@ static void avrcp_controller_emit_notification_for_event_id(uint16_t avrcp_cid, 
             (*avrcp_controller_context.avrcp_callback)(HCI_EVENT_PACKET, 0, event, offset);
             break;
         }
+        case AVRCP_NOTIFICATION_EVENT_ADDRESSED_PLAYER_CHANGED:{
+            if (size < 4) break;
+            uint16_t player_id = big_endian_read_16(payload, 0);
+            uint16_t uid_counter = big_endian_read_16(payload, 2);
+            uint16_t offset = 0;
+            uint8_t event[10];
+            event[offset++] = HCI_EVENT_AVRCP_META;
+            event[offset++] = sizeof(event) - 2;
+            event[offset++] = AVRCP_SUBEVENT_NOTIFICATION_ADDRESSED_PLAYER_CHANGED;
+            little_endian_store_16(event, offset, avrcp_cid);
+            offset += 2;
+            event[offset++] = ctype;
+            little_endian_store_16(event, offset, player_id);
+            offset += 2;
+            little_endian_store_16(event, offset, uid_counter);
+            offset += 2;
+            (*avrcp_controller_context.avrcp_callback)(HCI_EVENT_PACKET, 0, event, offset);
+        }
         case AVRCP_NOTIFICATION_EVENT_VOLUME_CHANGED:{
             if (size < 1) break;
             uint16_t offset = 0;


### PR DESCRIPTION
This PR implements the `EVENT_ADDRESSED_PLAYER_CHANGED` AVRCP notification. Not much more to say here, actually.

Tested on Android 12 and iPhone 7.

Oh, and I used the event generator tool this time :smile: 