### PR TITLE
avrcp_controller: report track identifier in track changed notification

### DIFF
--- a/src/btstack_defines.h
+++ b/src/btstack_defines.h
@@ -3280,10 +3280,11 @@ typedef SSIZE_T ssize_t;
 #define AVRCP_SUBEVENT_NOTIFICATION_PLAYBACK_STATUS_CHANGED                         0x01u
 
 /**
- * @format 121
+ * @format 121D
  * @param subevent_code
  * @param avrcp_cid
  * @param command_type
+ * @param identifier
  */
 #define AVRCP_SUBEVENT_NOTIFICATION_TRACK_CHANGED                                   0x02u
 

--- a/src/btstack_event.h
+++ b/src/btstack_event.h
@@ -11053,6 +11053,15 @@ static inline uint16_t avrcp_subevent_notification_track_changed_get_avrcp_cid(c
 static inline uint8_t avrcp_subevent_notification_track_changed_get_command_type(const uint8_t * event){
     return event[5];
 }
+/**
+ * @brief Get field identifier from event AVRCP_SUBEVENT_NOTIFICATION_TRACK_CHANGED
+ * @param event packet
+ * @return identifier
+ * @note: btstack_type D
+ */
+static inline const uint8_t * avrcp_subevent_notification_track_changed_get_identifier(const uint8_t * event){
+    return (const uint8_t *) &event[6];
+}
 
 /**
  * @brief Get field avrcp_cid from event AVRCP_SUBEVENT_NOTIFICATION_EVENT_TRACK_REACHED_END

--- a/src/classic/avrcp_controller.c
+++ b/src/classic/avrcp_controller.c
@@ -227,13 +227,19 @@ static void avrcp_controller_emit_notification_for_event_id(uint16_t avrcp_cid, 
         }
         case AVRCP_NOTIFICATION_EVENT_TRACK_CHANGED:{
             uint16_t offset = 0;
-            uint8_t event[6];
+            uint8_t event[14];
             event[offset++] = HCI_EVENT_AVRCP_META;
             event[offset++] = sizeof(event) - 2;
             event[offset++] = AVRCP_SUBEVENT_NOTIFICATION_TRACK_CHANGED;
             little_endian_store_16(event, offset, avrcp_cid);
             offset += 2;
             event[offset++] = ctype;
+            if (size >= 8){
+                memcpy(&event[offset], &payload[0], 8);
+            } else {
+                memset(&event[offset], 0, 8);
+            }
+            offset += 8;
             (*avrcp_controller_context.avrcp_callback)(HCI_EVENT_PACKET, 0, event, offset);
             break;
         }


### PR DESCRIPTION
This PR adds the track UID to `EVENT_TRACK_CHANGED` AVRCP notification.

Previously, this event was reported with no additional data. However, this UID can be useful to determine which track from the NowPlaying directory is currently being played.

To keep compatibility with older versions of AVRCP, the field will be zeroed-out if it's not present in the received notification (to best of my knowledge, it's supported in at least AVRCP v1.3+).