### PR TITLE
hci_transport_h2_libusb: Support filtering devices by hub number.

### DIFF
--- a/src/hci_transport_usb.h
+++ b/src/hci_transport_usb.h
@@ -62,6 +62,11 @@ const hci_transport_t * hci_transport_usb_instance(void);
 void hci_transport_usb_set_path(int len, uint8_t * port_numbers);
 
 /**
+ * @brief Specify USB Bluetooth device via bus and port numbers from hub to device
+ */
+void hci_transport_usb_set_bus_and_path(uint8_t bus, int len, uint8_t* port_numbers);
+
+/**
  * @brief Add device to list of known Bluetooth USB Controller
  * @param vendor_id
  * @param product_id


### PR DESCRIPTION
The unique location of a device in the USB device tree consists of the hub ID and then the port numbers/path. Without additionally filtering by USB hub ID, we only allow ambiguously addressing USB devices.

Tested via building ports/libusb/gap_inquiry and validating that:

1. Specifying the wrong hub number results in the same hanging behavior as specifying the wrong path.
2. Specifying the right hub number behaves the same way as specifying the right path.
3. Specifying just the hub number returns an error (this is dependent on command line handing).

Example run:

```
jaguilar@DESKTOP-2GF79BV:~/projects/btstack$ make -C port/libusb all >/dev/null 2>/dev/null  && ./port/libusb/gap_inquiry -b 1 -u 3
Specified USB Path: 03 
Packet Log: /tmp/hci_dump_3.pklg
USB device 0x2357/0x0604, path: 03
Local version information:
- HCI Version    0x000a
- HCI Revision   0x000b
- LMP Version    0x000a
- LMP Subversion 0x8761
- Manufacturer   0x005d
TLV path: /tmp/btstack_0C-EF-15-BF-17-A8.tlv
BTstack up and running on 0C:EF:15:BF:17:A8.
Starting inquiry scan..
^CCTRL-C - SIGINT received, shutting down..
jaguilar@DESKTOP-2GF79BV:~/projects/btstack$ lsusb -t
/:  Bus 001.Port 001: Dev 001, Class=root_hub, Driver=vhci_hcd/8p, 480M
    |__ Port 002: Dev 003, If 0, Class=Communications, Driver=[none], 12M
    |__ Port 002: Dev 003, If 1, Class=CDC Data, Driver=[none], 12M
    |__ Port 002: Dev 003, If 2, Class=Vendor Specific Class, Driver=[none], 12M
    |__ Port 003: Dev 041, If 0, Class=Wireless, Driver=[none], 12M
    |__ Port 003: Dev 041, If 1, Class=Wireless, Driver=[none], 12M
/:  Bus 002.Port 001: Dev 001, Class=root_hub, Driver=vhci_hcd/8p, 5000M
```

Resolves #717.