### PR TITLE
Fix ESP32 port for IDF 6.

### DIFF
--- a/port/esp32/components/btstack/CMakeLists.txt
+++ b/port/esp32/components/btstack/CMakeLists.txt
@@ -110,7 +110,9 @@ set(priv_include_dirs
 set(priv_requires
         "nvs_flash"
         "bt"
-        "driver"
+        "esp_driver_gpio"
+        "esp_driver_uart"
+        "esp_driver_i2s"
         "lwip"
         "vfs"
         )


### PR DESCRIPTION
IDF 6 has removed the monolithic "driver" component and broken it out into more specific components. Thus the ESP32 port does not compile on IDF 6.

This change replaces the driver component with the 3 that are actually needed. This is backwards compatible to IDF 5.5.