### PR TITLE
Don't store key in sm_process_bonding_information

### DIFF
--- a/src/ble/sm.c
+++ b/src/ble/sm.c
@@ -1603,10 +1603,6 @@ static void sm_process_bonding_information(sm_connection_t * sm_conn){
 #endif
         sm_store_le_bonding_information(sm_conn, le_db_index);
     }
-
-#ifdef ENABLE_CROSS_TRANSPORT_KEY_DERIVATION
-    sm_store_classic_bonding_information(sm_conn);
-#endif
 }
 
 static void sm_pairing_error(sm_connection_t * sm_conn, uint8_t reason){
@@ -1658,6 +1654,12 @@ static void sm_key_distribution_handle_all_received(sm_connection_t * sm_conn){
 
     if (bonding_enabled){
         sm_process_bonding_information(sm_conn);
+#ifdef ENABLE_CROSS_TRANSPORT_KEY_DERIVATION
+        // Only for the LE -> BR/EDR direction: setup->sm_link_key was derived here and reversed into
+        // HCI byte order. In the BR/EDR -> LE direction it holds the *existing* link key in SM byte
+        // order (see sm_ctkd_fetch_br_edr_link_key), and storing it would corrupt the link key db.
+        sm_store_classic_bonding_information(sm_conn);
+#endif
     } else {
         log_info("Ignoring received keys, bonding not enabled");
     }


### PR DESCRIPTION
sm_process_bonding_information is called in two situations,

1/ a brand-new classic link key is derived from the LE LTK and written into setup->sm_link_key via reverse_128 to be converted out of crypto order into HCI order. It must be persisted, and it's in the right order

2/ CTKD BR/EDR → LE. The classic link key is the input, not an output. Classic SSP already completed and wrote the key correctly to the DB. A copy of the key was loaded into setup->sm_link_key, reversed. It rewrote the entry in flash with the reversed copy.

The fix is to make sure sm_process_bonding_information is only called when setup->sm_link_key holds a newly derived key in HCI order, and never when it holds a borrowed key in SM order.

Fixes #744