### PR TITLE
Fix assert caused by sm_ctkd_from_classic

### DIFF
--- a/src/ble/sm.c
+++ b/src/ble/sm.c
@@ -2663,7 +2663,7 @@ static bool sm_ctkd_from_classic(sm_connection_t * sm_connection){
     if (index >= 0){
         int ltk_authenticated;
         sm_key_t ltk;
-        le_device_db_encryption_get(sm_connection->sm_le_db_index, NULL, NULL, ltk, NULL, &ltk_authenticated, NULL, NULL);
+        le_device_db_encryption_get(index, NULL, NULL, ltk, NULL, &ltk_authenticated, NULL, NULL);
         bool have_ltk = !sm_is_null_key(ltk);
         if (have_ltk && ltk_authenticated) return false;
     }


### PR DESCRIPTION
sm_ctkd_from_classic looks up an LE device db index, checks it's valid and then passes a different variable to le_device_db_encryption_get.

On a BR/EDR connection the variable it actually passes is still -1 from sm_connection_init because no LE address resolution has run on it.

So in debug an assertion fails. In release the CTKD security decision is taken from uninitialised stack memory and unless you're unlucky the pairing appears to work?

Fixes #746