### PR TITLE
Allow BD addresses to be changed at build time

### DIFF
--- a/example/a2dp_sink_demo.c
+++ b/example/a2dp_sink_demo.c
@@ -100,7 +100,10 @@
 #define RESAMPLE_OUTPUT_FRAMES         (SBC_MAX_AUDIO_FRAMES_PER_BLOCK + RESAMPLE_ADDITIONAL_FRAMES)
 
 #ifdef HAVE_BTSTACK_STDIN
-static const char * device_addr_string = "00:1B:DC:08:E2:72"; // pts v5.0
+#ifndef REMOTE_ADDR_STRING
+#define REMOTE_ADDR_STRING "00:1B:DC:08:E2:72" // pts v5.0
+#endif
+static const char * device_addr_string = REMOTE_ADDR_STRING;
 #endif
 static bd_addr_t device_addr;
 

--- a/example/a2dp_source_demo.c
+++ b/example/a2dp_source_demo.c
@@ -160,7 +160,10 @@ typedef struct {
 static btstack_packet_callback_registration_t hci_event_callback_registration;
 
 // Minijambox:
-static const char * device_addr_string = "00:21:3C:AC:F7:38";
+#ifndef REMOTE_ADDR_STRING
+#define REMOTE_ADDR_STRING "00:21:3C:AC:F7:38"
+#endif
+static const char * device_addr_string = REMOTE_ADDR_STRING;
 
 static bd_addr_t device_addr;
 static bool scan_active;

--- a/example/avrcp_browsing_client.c
+++ b/example/avrcp_browsing_client.c
@@ -79,7 +79,10 @@
 
 #ifdef HAVE_BTSTACK_STDIN
 // Minijambox:
-static const char * device_addr_string = "00:21:3C:AC:F7:38";
+#ifndef REMOTE_ADDR_STRING
+#define REMOTE_ADDR_STRING "00:21:3C:AC:F7:38"
+#endif
+static const char * device_addr_string = REMOTE_ADDR_STRING;
 #endif
 static bd_addr_t device_addr;
 

--- a/example/gap_dedicated_bonding.c
+++ b/example/gap_dedicated_bonding.c
@@ -45,7 +45,10 @@
 
 #include "btstack.h"
 
-static const char * device_addr_string = "00:1A:7D:DA:71:03";
+#ifndef REMOTE_ADDR_STRING
+#define REMOTE_ADDR_STRING "00:1A:7D:DA:71:03"
+#endif
+static const char * device_addr_string = REMOTE_ADDR_STRING;
 static bd_addr_t device_addr;
 
 static const int mitm_protection_required = 0;

--- a/example/hfp_ag_demo.c
+++ b/example/hfp_ag_demo.c
@@ -71,7 +71,10 @@ const uint8_t    rfcomm_channel_nr = 1;
 const char hfp_ag_service_name[] = "HFP AG Demo";
 
 static bd_addr_t device_addr;
-static const char * device_addr_string = "00:1A:7D:DA:71:03";
+#ifndef REMOTE_ADDR_STRING
+#define REMOTE_ADDR_STRING "00:1A:7D:DA:71:03"
+#endif
+static const char * device_addr_string = REMOTE_ADDR_STRING;
 
 static uint8_t codecs[] = {
         HFP_CODEC_CVSD,

--- a/example/hfp_hf_demo.c
+++ b/example/hfp_hf_demo.c
@@ -70,7 +70,10 @@ const char hfp_hf_service_name[] = "HFP HF Demo";
 
 #ifdef HAVE_BTSTACK_STDIN
 // static const char * device_addr_string = "6C:72:E7:10:22:EE";
-static const char * device_addr_string = "00:02:72:DC:31:C1";
+#ifndef REMOTE_ADDR_STRING
+#define REMOTE_ADDR_STRING "00:02:72:DC:31:C1"
+#endif
+static const char * device_addr_string = REMOTE_ADDR_STRING;
 #endif
 
 static bd_addr_t device_addr;

--- a/example/hid_host_demo.c
+++ b/example/hid_host_demo.c
@@ -56,7 +56,10 @@
 
 #define MAX_ATTRIBUTE_VALUE_SIZE 300
 
-static const char * remote_addr_string = "00:1A:7D:DA:71:01";
+#ifndef REMOTE_ADDR_STRING
+#define REMOTE_ADDR_STRING "00:1A:7D:DA:71:01"
+#endif
+static const char * remote_addr_string = REMOTE_ADDR_STRING;
 
 static bd_addr_t remote_addr;
 

--- a/example/hid_keyboard_demo.c
+++ b/example/hid_keyboard_demo.c
@@ -200,7 +200,10 @@ static bool                   send_active;
 
 static bd_addr_t device_addr;
 #ifdef HAVE_BTSTACK_STDIN
-static const char * device_addr_string = "BC:EC:5D:E6:15:03";
+#ifndef REMOTE_ADDR_STRING
+#define REMOTE_ADDR_STRING "BC:EC:5D:E6:15:03"
+#endif
+static const char * device_addr_string = REMOTE_ADDR_STRING;
 #endif
 
 // used to store remote device in TLV

--- a/example/hsp_ag_demo.c
+++ b/example/hsp_ag_demo.c
@@ -73,7 +73,10 @@ static uint16_t      sco_handle = HCI_CON_HANDLE_INVALID;
 static char hs_cmd_buffer[100];
 
 static const char * device_name = "HSP AG Demo 00:00:00:00:00:00";
-static const char * device_addr_string = "00:1b:dc:07:32:ef";
+#ifndef REMOTE_ADDR_STRING
+#define REMOTE_ADDR_STRING "00:1b:dc:07:32:ef"
+#endif
+static const char * device_addr_string = REMOTE_ADDR_STRING;
 static bd_addr_t device_addr;
 
 /* @section Audio Transfer Setup 

--- a/example/hsp_hs_demo.c
+++ b/example/hsp_hs_demo.c
@@ -74,7 +74,10 @@ static hci_con_handle_t sco_handle = HCI_CON_HANDLE_INVALID;
 
 static char hs_cmd_buffer[100];
 // mac 2013: 
-static const char * device_addr_string = "84:38:35:65:d1:15";
+#ifndef REMOTE_ADDR_STRING
+#define REMOTE_ADDR_STRING "84:38:35:65:d1:15"
+#endif
+static const char * device_addr_string = REMOTE_ADDR_STRING;
 static bd_addr_t device_addr;
 
 /* @section Audio Transfer Setup 

--- a/example/panu_demo.c
+++ b/example/panu_demo.c
@@ -86,7 +86,10 @@ static const unsigned int attribute_value_buffer_size = sizeof(attribute_value);
 #endif
 
 // MBP 2016
-static const char * remote_addr_string = "78:4F:43:8C:B2:5D";
+#ifndef REMOTE_ADDR_STRING
+#define REMOTE_ADDR_STRING "78:4F:43:8C:B2:5D"
+#endif
+static const char * remote_addr_string = REMOTE_ADDR_STRING;
 // Wiko Sunny static const char * remote_addr_string = "A0:4C:5B:0F:B2:42";
 
 static bd_addr_t remote_addr;

--- a/example/pbap_client_demo.c
+++ b/example/pbap_client_demo.c
@@ -68,7 +68,10 @@ static bd_addr_t    remote_addr;
 // Nexus 7 "30-85-A9-54-2E-78"
 // iPhone SE "BC:EC:5D:E6:15:03"
 // PTS "001BDC080AA5"
-static  char * remote_addr_string = "DC:52:85:B4:AD:2B ";
+#ifndef REMOTE_ADDR_STRING
+#define REMOTE_ADDR_STRING "DC:52:85:B4:AD:2B"
+#endif
+static  char * remote_addr_string = REMOTE_ADDR_STRING;
 
 
 #ifdef HAVE_BTSTACK_STDIN

--- a/example/sdp_bnep_query.c
+++ b/example/sdp_bnep_query.c
@@ -61,7 +61,10 @@ int attribute_id = -1;
 static uint8_t   attribute_value[1000];
 static const int attribute_value_buffer_size = sizeof(attribute_value);
 
-static bd_addr_t remote = {0x04,0x0C,0xCE,0xE4,0x85,0xD3};
+#ifndef REMOTE_ADDR_STRING
+#define REMOTE_ADDR_STRING "04:0C:CE:E4:85:D3"
+#endif
+static bd_addr_t remote;
 static btstack_packet_callback_registration_t hci_event_callback_registration;
 
 static void assertBuffer(int size){
@@ -270,6 +273,8 @@ int btstack_main(int argc, const char * argv[]);
 int btstack_main(int argc, const char * argv[]){
     (void)argc;
     (void)argv;
+
+    sscanf_bd_addr(REMOTE_ADDR_STRING, remote);
 
     printf("Client HCI init done\r\n");
 

--- a/example/sdp_general_query.c
+++ b/example/sdp_general_query.c
@@ -59,7 +59,10 @@
 // Jambox static const char * remote_addr_string = "00:21:3C:AC:F7:38";
 // Mac static const char * remote_addr_string = "F0:18:98:60:3E:E5";
 // iPhone 5S: 
-static const char * remote_addr_string = "6C:72:E7:10:22:EE";
+#ifndef REMOTE_ADDR_STRING
+#define REMOTE_ADDR_STRING "6C:72:E7:10:22:EE"
+#endif
+static const char * remote_addr_string = REMOTE_ADDR_STRING;
 #endif
 
 static bd_addr_t remote_addr;

--- a/example/sdp_rfcomm_query.c
+++ b/example/sdp_rfcomm_query.c
@@ -63,7 +63,10 @@
 
 static void handle_query_rfcomm_event(uint8_t packet_type, uint16_t channel, uint8_t *packet, uint16_t size);
 
-static bd_addr_t remote = {0x84, 0x38, 0x35, 0x65, 0xD1, 0x15};
+#ifndef REMOTE_ADDR_STRING
+#define REMOTE_ADDR_STRING "84:38:35:65:D1:15"
+#endif
+static bd_addr_t remote;
 
 static struct {
     uint8_t channel_nr;
@@ -153,6 +156,8 @@ int btstack_main(int argc, const char * argv[]);
 int btstack_main(int argc, const char * argv[]){
     (void)argc;
     (void)argv;
+
+    sscanf_bd_addr(REMOTE_ADDR_STRING, remote);
 
     // init L2CAP
     l2cap_init();


### PR DESCRIPTION
Currently you have to modify the source to change the BD address in the examples. Allow the address to be changed at build time by defining REMOTE_ADDR_STRING

target_compile_definitions(...
    REMOTE_ADDR_STRING="AA:BB:CC:DD:EE:FF"
)

This has always annoyed me :)